### PR TITLE
Switch query callback replies to rc

### DIFF
--- a/examples/arduino/z_get.ino
+++ b/examples/arduino/z_get.ino
@@ -42,7 +42,7 @@ void reply_dropper(void *ctx) {
     Serial.println(" >> Received query final notification");
 }
 
-void reply_handler(z_owned_reply_t *oreply, void *ctx) {
+void reply_handler(const z_loaned_reply_t *oreply, void *ctx) {
     (void)(ctx);
     if (z_reply_is_ok(oreply)) {
         const z_loaned_sample_t *sample = z_reply_ok(oreply);

--- a/examples/espidf/z_get.c
+++ b/examples/espidf/z_get.c
@@ -103,7 +103,7 @@ void wifi_init_sta(void) {
 
 void reply_dropper(void *ctx) { printf(" >> Received query final notification\n"); }
 
-void reply_handler(z_owned_reply_t *oreply, void *ctx) {
+void reply_handler(const z_loaned_reply_t *oreply, void *ctx) {
     if (z_reply_is_ok(oreply)) {
         const z_loaned_sample_t *sample = z_reply_ok(oreply);
         z_owned_str_t keystr;

--- a/examples/freertos_plus_tcp/z_get.c
+++ b/examples/freertos_plus_tcp/z_get.c
@@ -36,7 +36,7 @@ void reply_dropper(void *ctx) {
     printf(">> Received query final notification\n");
 }
 
-void reply_handler(z_owned_reply_t *reply, void *ctx) {
+void reply_handler(const z_loaned_reply_t *reply, void *ctx) {
     (void)(ctx);
     if (z_reply_is_ok(reply)) {
         const z_loaned_sample_t *sample = z_reply_ok(reply);

--- a/examples/mbed/z_get.cpp
+++ b/examples/mbed/z_get.cpp
@@ -33,7 +33,7 @@
 
 void reply_dropper(void *ctx) { printf(" >> Received query final notification\n"); }
 
-void reply_handler(z_owned_reply_t *oreply, void *ctx) {
+void reply_handler(const z_loaned_reply_t *oreply, void *ctx) {
     if (z_reply_is_ok(oreply)) {
         const z_loaned_sample_t *sample = z_reply_ok(oreply);
         z_owned_str_t keystr;

--- a/examples/unix/c11/z_get.c
+++ b/examples/unix/c11/z_get.c
@@ -37,7 +37,7 @@ int8_t attachment_handler(z_bytes_t key, z_bytes_t att_value, void *ctx) {
 }
 #endif
 
-void reply_handler(z_owned_reply_t *reply, void *ctx) {
+void reply_handler(const z_loaned_reply_t *reply, void *ctx) {
     (void)(ctx);
     if (z_reply_is_ok(reply)) {
         const z_loaned_sample_t *sample = z_reply_ok(reply);

--- a/examples/unix/c11/z_get_channel.c
+++ b/examples/unix/c11/z_get_channel.c
@@ -103,8 +103,8 @@ int main(int argc, char **argv) {
     z_owned_reply_t reply;
     z_null(&reply);
     for (z_call(channel.recv, &reply); z_check(reply); z_call(channel.recv, &reply)) {
-        if (z_reply_is_ok(&reply)) {
-            const z_loaned_sample_t *sample = z_reply_ok(&reply);
+        if (z_reply_is_ok(z_loan(reply))) {
+            const z_loaned_sample_t *sample = z_reply_ok(z_loan(reply));
             z_owned_str_t keystr;
             z_keyexpr_to_string(z_sample_keyexpr(sample), &keystr);
             printf(">> Received ('%s': '%.*s')\n", z_str_data(z_loan(keystr)), (int)z_sample_payload(sample)->len,

--- a/examples/unix/c99/z_get.c
+++ b/examples/unix/c99/z_get.c
@@ -29,7 +29,7 @@ void reply_dropper(void *ctx) {
     z_condvar_free(&cond);
 }
 
-void reply_handler(z_owned_reply_t *reply, void *ctx) {
+void reply_handler(const z_loaned_reply_t *reply, void *ctx) {
     (void)(ctx);
     if (z_reply_is_ok(reply)) {
         const z_loaned_sample_t *sample = z_reply_ok(reply);

--- a/examples/windows/z_get.c
+++ b/examples/windows/z_get.c
@@ -28,7 +28,7 @@ void reply_dropper(void *ctx) {
     z_condvar_free(&cond);
 }
 
-void reply_handler(z_owned_reply_t *reply, void *ctx) {
+void reply_handler(const z_loaned_reply_t *reply, void *ctx) {
     (void)(ctx);
     if (z_reply_is_ok(reply)) {
         const z_loaned_sample_t *sample = z_reply_ok(reply);

--- a/examples/zephyr/z_get.c
+++ b/examples/zephyr/z_get.c
@@ -33,7 +33,7 @@
 
 void reply_dropper(void *ctx) { printf(" >> Received query final notification\n"); }
 
-void reply_handler(z_owned_reply_t *oreply, void *ctx) {
+void reply_handler(const z_loaned_reply_t *oreply, void *ctx) {
     if (z_reply_is_ok(oreply)) {
         const z_loaned_sample_t *sample = z_reply_ok(oreply);
         z_owned_str_t keystr;

--- a/include/zenoh-pico/api/handlers.h
+++ b/include/zenoh-pico/api/handlers.h
@@ -33,7 +33,7 @@ z_owned_query_t *_z_query_to_owned_ptr(const z_loaned_query_t *src);
 
 // -- Reply handler
 void _z_owned_reply_move(z_owned_reply_t *dst, z_owned_reply_t *src);
-z_owned_reply_t *_z_reply_clone(const z_owned_reply_t *src);
+z_owned_reply_t *_z_reply_to_owned_ptr(const z_loaned_reply_t *src);
 
 // -- Channel
 #define _Z_CHANNEL_DEFINE(name, send_closure_name, recv_closure_name, send_type, recv_type, collection_type, \
@@ -112,13 +112,13 @@ _Z_CHANNEL_DEFINE(query_fifo_channel, closure_query, closure_owned_query, const 
                   _z_owned_query_move, _z_query_to_owned_ptr, z_query_drop)
 
 // z_owned_reply_ring_channel_t
-_Z_CHANNEL_DEFINE(reply_ring_channel, closure_reply, closure_reply, z_owned_reply_t, z_owned_reply_t, _z_ring_mt_t,
-                  _z_ring_mt_new, _z_ring_mt_free, _z_ring_mt_push, _z_ring_mt_pull, _z_ring_mt_try_pull,
-                  _z_owned_reply_move, _z_reply_clone, z_reply_drop)
+_Z_CHANNEL_DEFINE(reply_ring_channel, closure_reply, closure_owned_reply, const z_loaned_reply_t, z_owned_reply_t,
+                  _z_ring_mt_t, _z_ring_mt_new, _z_ring_mt_free, _z_ring_mt_push, _z_ring_mt_pull, _z_ring_mt_try_pull,
+                  _z_owned_reply_move, _z_reply_to_owned_ptr, z_reply_drop)
 
 // z_owned_reply_fifo_channel_t
-_Z_CHANNEL_DEFINE(reply_fifo_channel, closure_reply, closure_reply, z_owned_reply_t, z_owned_reply_t, _z_fifo_mt_t,
-                  _z_fifo_mt_new, _z_fifo_mt_free, _z_fifo_mt_push, _z_fifo_mt_pull, _z_fifo_mt_try_pull,
-                  _z_owned_reply_move, _z_reply_clone, z_reply_drop)
+_Z_CHANNEL_DEFINE(reply_fifo_channel, closure_reply, closure_owned_reply, const z_loaned_reply_t, z_owned_reply_t,
+                  _z_fifo_mt_t, _z_fifo_mt_new, _z_fifo_mt_free, _z_fifo_mt_push, _z_fifo_mt_pull, _z_fifo_mt_try_pull,
+                  _z_owned_reply_move, _z_reply_to_owned_ptr, z_reply_drop)
 
 #endif  // INCLUDE_ZENOH_PICO_API_HANDLERS_H

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -351,15 +351,15 @@ inline bool z_check(const z_owned_hello_t& v) { return z_hello_check(&v); }
 inline bool z_check(const z_owned_str_t& v) { return z_str_check(&v); }
 inline bool z_check(const z_owned_str_t& v) { return z_sample_check(&v); }
 
-inline void z_call(const z_owned_closure_sample_t &closure, const z_sample_t *sample) 
+inline void z_call(const z_owned_closure_sample_t &closure, const z_loaned_sample_t *sample) 
     { z_closure_sample_call(&closure, sample); }
-inline void z_call(const z_owned_closure_owned_sample_t &closure, const z_sample_t *sample) 
+inline void z_call(const z_owned_closure_owned_sample_t &closure, const z_owned_sample_t *sample) 
     { z_closure_owned_sample_call(&closure, sample); }
-inline void z_call(const z_owned_closure_query_t &closure, const z_query_t *query)
+inline void z_call(const z_owned_closure_query_t &closure, const z_loaned_query_t *query)
     { z_closure_query_call(&closure, query); }
-inline void z_call(const z_owned_closure_owned_query_t &closure, const z_query_t *query) 
+inline void z_call(const z_owned_closure_owned_query_t &closure, const z_owned_query_t *query) 
     { z_closure_owned_query_call(&closure, query); }
-inline void z_call(const z_owned_closure_reply_t &closure, const z_reply_t *reply)
+inline void z_call(const z_owned_closure_reply_t &closure, const z_loaned_reply_t *reply)
     { z_closure_reply_call(&closure, reply); }
 inline void z_call(const z_owned_closure_owned_reply_t &closure, z_owned_reply_t *reply)
     { z_closure_owned_reply_call(&closure, reply); }

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -46,7 +46,7 @@
                   z_view_str_t : z_view_str_loan,                     \
                   z_owned_str_array_t : z_str_array_loan,             \
                   z_owned_sample_t : z_sample_loan,                   \
-                  z_owned_query_t : z_query_loan                     \
+                  z_owned_query_t : z_query_loan                      \
             )(&x)
 
 #define z_loan_mut(x) _Generic((x), \

--- a/include/zenoh-pico/api/macros.h
+++ b/include/zenoh-pico/api/macros.h
@@ -46,7 +46,7 @@
                   z_view_str_t : z_view_str_loan,                     \
                   z_owned_str_array_t : z_str_array_loan,             \
                   z_owned_sample_t : z_sample_loan,                   \
-                  z_owned_query_t : z_query_loan                      \
+                  z_owned_query_t : z_query_loan                     \
             )(&x)
 
 #define z_loan_mut(x) _Generic((x), \
@@ -120,7 +120,7 @@
                   z_owned_hello_t : z_hello_check,                     \
                   z_owned_str_t : z_str_check,                         \
                   z_owned_str_array_t : z_str_array_check,             \
-                  z_owned_bytes_t : z_bytes_check,                           \
+                  z_owned_bytes_t : z_bytes_check,                     \
                   z_owned_sample_t : z_sample_check,                   \
                   z_owned_query_t : z_query_check                      \
             )(&x)
@@ -138,7 +138,8 @@
                   z_owned_closure_hello_t : z_closure_hello_call,                   \
                   z_owned_closure_zid_t : z_closure_zid_call,                       \
                   z_owned_closure_owned_sample_t : z_closure_owned_sample_call,     \
-                  z_owned_closure_owned_query_t : z_closure_owned_query_call        \
+                  z_owned_closure_owned_query_t : z_closure_owned_query_call,       \
+                  z_owned_closure_owned_reply_t : z_closure_owned_reply_call        \
             ) (&x, __VA_ARGS__)
 
 /**
@@ -358,8 +359,10 @@ inline void z_call(const z_owned_closure_query_t &closure, const z_query_t *quer
     { z_closure_query_call(&closure, query); }
 inline void z_call(const z_owned_closure_owned_query_t &closure, const z_query_t *query) 
     { z_closure_owned_query_call(&closure, query); }
-inline void z_call(const z_owned_closure_reply_t &closure, z_owned_reply_t *reply)
+inline void z_call(const z_owned_closure_reply_t &closure, const z_reply_t *reply)
     { z_closure_reply_call(&closure, reply); }
+inline void z_call(const z_owned_closure_owned_reply_t &closure, z_owned_reply_t *reply)
+    { z_closure_owned_reply_call(&closure, reply); }
 inline void z_call(const z_owned_closure_hello_t &closure, z_owned_hello_t *hello)
     { z_closure_hello_call(&closure, hello); }
 inline void z_call(const z_owned_closure_zid_t &closure, const z_id_t *zid)

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -1214,7 +1214,7 @@ const z_loaned_sample_t *z_reply_ok(const z_loaned_reply_t *reply);
  * Returns:
  *   Returns the :c:type:`z_value_t` wrapped in the query reply.
  */
-z_value_t z_reply_err(const z_owned_reply_t *reply);
+z_value_t z_reply_err(const z_loaned_reply_t *reply);
 #endif
 
 #if Z_FEATURE_QUERYABLE == 1

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -584,7 +584,7 @@ const z_loaned_keyexpr_t *z_query_keyexpr(const z_loaned_query_t *query);
  * Returns:
  *   Returns a new sample closure.
  */
-int8_t z_closure_sample(z_owned_closure_sample_t *closure, _z_data_handler_t call, _z_dropper_handler_t drop,
+int8_t z_closure_sample(z_owned_closure_sample_t *closure, z_data_handler_t call, z_dropper_handler_t drop,
                         void *context);
 
 /**
@@ -608,8 +608,8 @@ int8_t z_closure_sample(z_owned_closure_sample_t *closure, _z_data_handler_t cal
  * Returns:
  *   Returns a new sample closure.
  */
-int8_t z_closure_owned_sample(z_owned_closure_owned_sample_t *closure, _z_owned_sample_handler_t call,
-                              _z_dropper_handler_t drop, void *context);
+int8_t z_closure_owned_sample(z_owned_closure_owned_sample_t *closure, z_owned_sample_handler_t call,
+                              z_dropper_handler_t drop, void *context);
 
 /**
  * Return a new query closure.
@@ -636,7 +636,7 @@ int8_t z_closure_owned_sample(z_owned_closure_owned_sample_t *closure, _z_owned_
  * Returns:
  *   Returns a new query closure.
  */
-int8_t z_closure_query(z_owned_closure_query_t *closure, _z_queryable_handler_t call, _z_dropper_handler_t drop,
+int8_t z_closure_query(z_owned_closure_query_t *closure, z_queryable_handler_t call, z_dropper_handler_t drop,
                        void *context);
 
 /**
@@ -660,8 +660,8 @@ int8_t z_closure_query(z_owned_closure_query_t *closure, _z_queryable_handler_t 
  * Returns:
  *   Returns a new query closure.
  */
-int8_t z_closure_owned_query(z_owned_closure_owned_query_t *closure, _z_owned_query_handler_t call,
-                             _z_dropper_handler_t drop, void *context);
+int8_t z_closure_owned_query(z_owned_closure_owned_query_t *closure, z_owned_query_handler_t call,
+                             z_dropper_handler_t drop, void *context);
 
 /**
  * Return a new reply closure.
@@ -688,7 +688,7 @@ int8_t z_closure_owned_query(z_owned_closure_owned_query_t *closure, _z_owned_qu
  * Returns:
  *   Returns a new reply closure.
  */
-int8_t z_closure_reply(z_owned_closure_reply_t *closure, _z_reply_handler_t call, _z_dropper_handler_t drop,
+int8_t z_closure_reply(z_owned_closure_reply_t *closure, z_reply_handler_t call, z_dropper_handler_t drop,
                        void *context);
 
 /**
@@ -717,7 +717,7 @@ int8_t z_closure_reply(z_owned_closure_reply_t *closure, _z_reply_handler_t call
  *   Returns a new reply closure.
  */
 int8_t z_closure_owned_reply(z_owned_closure_owned_reply_t *closure, z_owned_reply_handler_t call,
-                             _z_dropper_handler_t drop, void *context);
+                             z_dropper_handler_t drop, void *context);
 
 /**
  * Return a new hello closure.
@@ -744,7 +744,7 @@ int8_t z_closure_owned_reply(z_owned_closure_owned_reply_t *closure, z_owned_rep
  * Returns:
  *   Returns a new hello closure.
  */
-int8_t z_closure_hello(z_owned_closure_hello_t *closure, z_owned_hello_handler_t call, _z_dropper_handler_t drop,
+int8_t z_closure_hello(z_owned_closure_hello_t *closure, z_owned_hello_handler_t call, z_dropper_handler_t drop,
                        void *context);
 
 /**
@@ -772,7 +772,7 @@ int8_t z_closure_hello(z_owned_closure_hello_t *closure, z_owned_hello_handler_t
  * Returns:
  *   Returns a new zid closure.
  */
-int8_t z_closure_zid(z_owned_closure_zid_t *closure, z_id_handler_t call, _z_dropper_handler_t drop, void *context);
+int8_t z_closure_zid(z_owned_closure_zid_t *closure, z_id_handler_t call, z_dropper_handler_t drop, void *context);
 
 /**************** Loans ****************/
 #define _OWNED_FUNCTIONS(loanedtype, ownedtype, name)             \

--- a/include/zenoh-pico/api/primitives.h
+++ b/include/zenoh-pico/api/primitives.h
@@ -688,8 +688,36 @@ int8_t z_closure_owned_query(z_owned_closure_owned_query_t *closure, _z_owned_qu
  * Returns:
  *   Returns a new reply closure.
  */
-int8_t z_closure_reply(z_owned_closure_reply_t *closure, z_owned_reply_handler_t call, _z_dropper_handler_t drop,
+int8_t z_closure_reply(z_owned_closure_reply_t *closure, _z_reply_handler_t call, _z_dropper_handler_t drop,
                        void *context);
+
+/**
+ * Return a new reply closure.
+ * It consists on a structure that contains all the elements for stateful, memory-leak-free callbacks.
+ *
+ * Like most ``z_owned_X_t`` types, you may obtain an instance of :c:type:`z_owned_closure_reply_t` by loaning it using
+ * ``z_closure_reply_loan(&val)``. The ``z_loan(val)`` macro, available if your compiler supports C11's ``_Generic``, is
+ * equivalent to writing ``z_closure_reply_loan(&val)``.
+ *
+ * Like all ``z_owned_X_t``, an instance will be destroyed by any function which takes a mutable pointer to said
+ * instance, as this implies the instance's inners were moved. To make this fact more obvious when reading your code,
+ * consider using ``z_move(val)`` instead of ``&val`` as the argument. After a ``z_move``, ``val`` will still exist, but
+ * will no longer be valid. The destructors are double-drop-safe, but other functions will still trust that your ``val``
+ * is valid.
+ *
+ * To check if ``val`` is still valid, you may use ``z_closure_reply_check(&val)`` or ``z_check(val)`` if your compiler
+ * supports ``_Generic``, which will return ``true`` if ``val`` is valid, or ``false`` otherwise.
+ *
+ * Parameters:
+ *   call: the typical callback function. ``context`` will be passed as its last argument.
+ *   drop: allows the callback's state to be freed. ``context`` will be passed as its last argument.
+ *   context: a pointer to an arbitrary state.
+ *
+ * Returns:
+ *   Returns a new reply closure.
+ */
+int8_t z_closure_owned_reply(z_owned_closure_owned_reply_t *closure, z_owned_reply_handler_t call,
+                             _z_dropper_handler_t drop, void *context);
 
 /**
  * Return a new hello closure.
@@ -782,6 +810,7 @@ _OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_sample_t, closure_owned_sample)
 _OWNED_FUNCTIONS_CLOSURE(z_owned_closure_query_t, closure_query)
 _OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_query_t, closure_owned_query)
 _OWNED_FUNCTIONS_CLOSURE(z_owned_closure_reply_t, closure_reply)
+_OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_reply_t, closure_owned_reply)
 _OWNED_FUNCTIONS_CLOSURE(z_owned_closure_hello_t, closure_hello)
 _OWNED_FUNCTIONS_CLOSURE(z_owned_closure_zid_t, closure_zid)
 
@@ -1159,7 +1188,7 @@ int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, co
  *   Returns ``true`` if the queryable answered with an OK, which allows this value to be treated as a sample, or
  * ``false`` otherwise.
  */
-_Bool z_reply_is_ok(const z_owned_reply_t *reply);
+_Bool z_reply_is_ok(const z_loaned_reply_t *reply);
 
 /**
  * Yields the contents of the reply by asserting it indicates a success.
@@ -1172,7 +1201,7 @@ _Bool z_reply_is_ok(const z_owned_reply_t *reply);
  * Returns:
  *   Returns the :c:type:`z_loaned_sample_t` wrapped in the query reply.
  */
-const z_loaned_sample_t *z_reply_ok(const z_owned_reply_t *reply);
+const z_loaned_sample_t *z_reply_ok(const z_loaned_reply_t *reply);
 
 /**
  * Yields the contents of the reply by asserting it indicates a failure.

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -480,8 +480,9 @@ _Bool z_str_array_is_empty(const z_str_array_t *a);
 _OWNED_TYPE_PTR(z_str_array_t, str_array)
 _LOANED_TYPE(z_str_array_t, str_array)
 
-typedef void (*_z_dropper_handler_t)(void *arg);
-typedef void (*_z_owned_sample_handler_t)(z_owned_sample_t *sample, void *arg);
+typedef void (*z_dropper_handler_t)(void *arg);
+typedef void (*z_owned_sample_handler_t)(z_owned_sample_t *sample, void *arg);
+typedef _z_data_handler_t z_data_handler_t;
 
 /**
  * Represents the sample closure.
@@ -489,15 +490,15 @@ typedef void (*_z_owned_sample_handler_t)(z_owned_sample_t *sample, void *arg);
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
  *
  * Members:
- *   _z_data_handler_t call: `void *call(const struct z_sample_t*, const void *context)` is the callback function.
- *   _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
+ *   z_data_handler_t call: `void *call(const struct z_sample_t*, const void *context)` is the callback function.
+ *   z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
  *   void *context: a pointer to an arbitrary state.
  */
 // TODO(sashacmc):
 typedef struct {
     void *context;
-    _z_data_handler_t call;
-    _z_dropper_handler_t drop;
+    z_data_handler_t call;
+    z_dropper_handler_t drop;
 } z_owned_closure_sample_t;
 
 void z_closure_sample_call(const z_owned_closure_sample_t *closure, const z_loaned_sample_t *sample);
@@ -508,19 +509,21 @@ void z_closure_sample_call(const z_owned_closure_sample_t *closure, const z_loan
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
  *
  * Members:
- *   _z_owned_sample_handler_t call: `void *call(const struct z_owned_sample_t*, const void *context)` is the callback
+ *   z_owned_sample_handler_t call: `void *call(const struct z_owned_sample_t*, const void *context)` is the callback
  *   function.
- * 	 _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed. void *context: a
+ * 	 z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed. void *context: a
  *   pointer to an arbitrary state.
  */
 // TODO(sashacmc):
 typedef struct {
     void *context;
-    _z_owned_sample_handler_t call;
-    _z_dropper_handler_t drop;
+    z_owned_sample_handler_t call;
+    z_dropper_handler_t drop;
 } z_owned_closure_owned_sample_t;
 
 void z_closure_owned_sample_call(const z_owned_closure_owned_sample_t *closure, z_owned_sample_t *sample);
+
+typedef _z_queryable_handler_t z_queryable_handler_t;
 
 /**
  * Represents the query callback closure.
@@ -530,19 +533,19 @@ void z_closure_owned_sample_call(const z_owned_closure_owned_sample_t *closure, 
  * Members:
  *   _z_queryable_handler_t call: `void (*_z_queryable_handler_t)(z_query_t *query, void *arg)` is the
  * callback function.
- *   _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
+ *   z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
  *   void *context: a pointer to an arbitrary state.
  */
 // TODO(sashacmc):
 typedef struct {
     void *context;
-    _z_queryable_handler_t call;
-    _z_dropper_handler_t drop;
+    z_queryable_handler_t call;
+    z_dropper_handler_t drop;
 } z_owned_closure_query_t;
 
 void z_closure_query_call(const z_owned_closure_query_t *closure, const z_loaned_query_t *query);
 
-typedef void (*_z_owned_query_handler_t)(z_owned_query_t *query, void *arg);
+typedef void (*z_owned_query_handler_t)(z_owned_query_t *query, void *arg);
 
 /**
  * Represents the owned query closure.
@@ -550,21 +553,22 @@ typedef void (*_z_owned_query_handler_t)(z_owned_query_t *query, void *arg);
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
  *
  * Members:
- *   _z_owned_query_handler_t call: `void *call(const struct z_owned_query_t*, const void *context)` is the callback
+ *   z_owned_query_handler_t call: `void *call(const struct z_owned_query_t*, const void *context)` is the callback
  *   function.
- * 	 _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed. void *context: a
+ * 	 z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed. void *context: a
  *   pointer to an arbitrary state.
  */
 // TODO(sashacmc):
 typedef struct {
     void *context;
-    _z_owned_query_handler_t call;
-    _z_dropper_handler_t drop;
+    z_owned_query_handler_t call;
+    z_dropper_handler_t drop;
 } z_owned_closure_owned_query_t;
 
 void z_closure_owned_query_call(const z_owned_closure_owned_query_t *closure, z_owned_query_t *query);
 
 typedef void (*z_owned_reply_handler_t)(z_owned_reply_t *reply, void *arg);
+typedef _z_reply_handler_t z_reply_handler_t;
 
 /**
  * Represents the query reply callback closure.
@@ -572,16 +576,16 @@ typedef void (*z_owned_reply_handler_t)(z_owned_reply_t *reply, void *arg);
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
  *
  * Members:
- *   _z_reply_handler_t call: `void (*_z_reply_handler_t)(_z_reply_t *reply, void *arg)` is the
+ *   z_reply_handler_t call: `void (*_z_reply_handler_t)(_z_reply_t *reply, void *arg)` is the
  * callback function.
- *   _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
+ *   z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
  *   void *context: a pointer to an arbitrary state.
  */
 // TODO(sashacmc):
 typedef struct {
     void *context;
-    _z_reply_handler_t call;
-    _z_dropper_handler_t drop;
+    z_reply_handler_t call;
+    z_dropper_handler_t drop;
 } z_owned_closure_reply_t;
 
 void z_closure_reply_call(const z_owned_closure_reply_t *closure, const z_loaned_reply_t *reply);
@@ -594,14 +598,14 @@ void z_closure_reply_call(const z_owned_closure_reply_t *closure, const z_loaned
  * Members:
  *   z_owned_reply_handler_t call: `void (*z_owned_reply_handler_t)(const z_owned_reply_t *reply, void *arg)` is the
  * callback function.
- *   _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
+ *   z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
  *   void *context: a pointer to an arbitrary state.
  */
 // TODO(sashacmc):
 typedef struct {
     void *context;
     z_owned_reply_handler_t call;
-    _z_dropper_handler_t drop;
+    z_dropper_handler_t drop;
 } z_owned_closure_owned_reply_t;
 
 void z_closure_owned_reply_call(const z_owned_closure_owned_reply_t *closure, z_owned_reply_t *reply);
@@ -616,14 +620,14 @@ typedef void (*z_owned_hello_handler_t)(z_owned_hello_t *hello, void *arg);
  * Members:
  *   z_owned_hello_handler_t call: `void (*z_owned_hello_handler_t)(const z_owned_hello_t *hello, void *arg)` is the
  * callback function.
- *   _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
+ *   z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
  *   void *context: a pointer to an arbitrary state.
  */
 // TODO(sashacmc):
 typedef struct {
     void *context;
     z_owned_hello_handler_t call;
-    _z_dropper_handler_t drop;
+    z_dropper_handler_t drop;
 } z_owned_closure_hello_t;
 
 void z_closure_hello_call(const z_owned_closure_hello_t *closure, z_owned_hello_t *hello);
@@ -637,14 +641,14 @@ typedef void (*z_id_handler_t)(const z_id_t *id, void *arg);
  *
  * Members:
  *   z_id_handler_t call: `void (*z_id_handler_t)(const z_id_t *id, void *arg)` is the callback function.
- *   _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
+ *   z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
  *   void *context: a pointer to an arbitrary state.
  */
 // TODO(sashacmc):
 typedef struct {
     void *context;
     z_id_handler_t call;
-    _z_dropper_handler_t drop;
+    z_dropper_handler_t drop;
 } z_owned_closure_zid_t;
 
 void z_closure_zid_call(const z_owned_closure_zid_t *closure, const z_id_t *id);

--- a/include/zenoh-pico/api/types.h
+++ b/include/zenoh-pico/api/types.h
@@ -181,7 +181,6 @@ _LOANED_TYPE(_z_queryable_t, queryable)
  * Represents a Zenoh query entity, received by Zenoh Queryable entities.
  *
  */
-
 _OWNED_TYPE_RC(_z_query_rc_t, query)
 _LOANED_TYPE(_z_query_rc_t, query)
 
@@ -459,8 +458,8 @@ typedef _z_reply_data_t z_reply_data_t;
  * Members:
  *   z_reply_data_t data: the content of the reply.
  */
-_OWNED_TYPE_PTR(_z_reply_t, reply)
-_LOANED_TYPE(_z_reply_t, reply)
+_OWNED_TYPE_RC(_z_reply_rc_t, reply)
+_LOANED_TYPE(_z_reply_rc_t, reply)
 
 /**
  * Represents an array of ``z_str_t``.
@@ -573,6 +572,26 @@ typedef void (*z_owned_reply_handler_t)(z_owned_reply_t *reply, void *arg);
  * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
  *
  * Members:
+ *   _z_reply_handler_t call: `void (*_z_reply_handler_t)(_z_reply_t *reply, void *arg)` is the
+ * callback function.
+ *   _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
+ *   void *context: a pointer to an arbitrary state.
+ */
+// TODO(sashacmc):
+typedef struct {
+    void *context;
+    _z_reply_handler_t call;
+    _z_dropper_handler_t drop;
+} z_owned_closure_reply_t;
+
+void z_closure_reply_call(const z_owned_closure_reply_t *closure, const z_loaned_reply_t *reply);
+
+/**
+ * Represents the owned query reply callback closure.
+ *
+ * A closure is a structure that contains all the elements for stateful, memory-leak-free callbacks.
+ *
+ * Members:
  *   z_owned_reply_handler_t call: `void (*z_owned_reply_handler_t)(const z_owned_reply_t *reply, void *arg)` is the
  * callback function.
  *   _z_dropper_handler_t drop: `void *drop(void*)` allows the callback's state to be freed.
@@ -583,9 +602,9 @@ typedef struct {
     void *context;
     z_owned_reply_handler_t call;
     _z_dropper_handler_t drop;
-} z_owned_closure_reply_t;
+} z_owned_closure_owned_reply_t;
 
-void z_closure_reply_call(const z_owned_closure_reply_t *closure, z_owned_reply_t *reply);
+void z_closure_owned_reply_call(const z_owned_closure_owned_reply_t *closure, z_owned_reply_t *reply);
 
 typedef void (*z_owned_hello_handler_t)(z_owned_hello_t *hello, void *arg);
 

--- a/include/zenoh-pico/net/primitives.h
+++ b/include/zenoh-pico/net/primitives.h
@@ -225,7 +225,7 @@ int8_t _z_send_reply(const _z_query_t *query, const _z_keyexpr_t keyexpr, const 
  */
 int8_t _z_query(_z_session_t *zn, _z_keyexpr_t keyexpr, const char *parameters, const z_query_target_t target,
                 const z_consolidation_mode_t consolidation, const _z_value_t value, _z_reply_handler_t callback,
-                void *arg_call, _z_drop_handler_t dropper, void *arg_drop, uint32_t timeout_ms
+                _z_drop_handler_t dropper, void *arg, uint32_t timeout_ms
 #if Z_FEATURE_ATTACHMENT == 1
                 ,
                 z_attachment_t attachment

--- a/include/zenoh-pico/net/reply.h
+++ b/include/zenoh-pico/net/reply.h
@@ -37,7 +37,7 @@ typedef struct _z_reply_data_t {
 
 void _z_reply_data_clear(_z_reply_data_t *rd);
 void _z_reply_data_copy(_z_reply_data_t *dst, _z_reply_data_t *src);
-_z_reply_t *_z_reply_alloc_and_move(_z_reply_t *_reply);
+_z_reply_t _z_reply_move(_z_reply_t *src_reply);
 
 _Z_ELEM_DEFINE(_z_reply_data, _z_reply_data_t, _z_noop_size, _z_reply_data_clear, _z_noop_copy)
 _Z_LIST_DEFINE(_z_reply_data, _z_reply_data_t)
@@ -55,9 +55,16 @@ typedef struct _z_reply_t {
     _z_reply_data_t data;
     z_reply_tag_t _tag;
 } _z_reply_t;
+
+_z_reply_t _z_reply_null(void);
 void _z_reply_clear(_z_reply_t *src);
 void _z_reply_free(_z_reply_t **hello);
 void _z_reply_copy(_z_reply_t *dst, _z_reply_t *src);
+_z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, const _z_bytes_t *payload,
+                           const _z_timestamp_t *timestamp, _z_encoding_t encoding, z_sample_kind_t kind,
+                           z_attachment_t att);
+
+_Z_REFCOUNT_DEFINE(_z_reply, _z_reply)
 
 typedef struct _z_pending_reply_t {
     _z_reply_t _reply;

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -110,19 +110,17 @@ _Z_LIST_DEFINE(_z_session_queryable_rc, _z_session_queryable_rc_t)
 typedef struct _z_reply_t _z_reply_t;
 typedef _z_list_t _z_reply_data_list_t;
 typedef _z_list_t _z_pending_reply_list_t;
-struct __z_reply_handler_wrapper_t;
 /**
  * The callback signature of the functions handling query replies.
  */
-typedef void (*_z_reply_handler_t)(_z_reply_t *reply, struct __z_reply_handler_wrapper_t *arg);
+typedef void (*_z_reply_handler_t)(_z_reply_t *reply, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;
     _z_zint_t _id;
     _z_reply_handler_t _callback;
     _z_drop_handler_t _dropper;
-    void *_call_arg;  // TODO[API-NET]: These two can be merged into one, when API and NET are a single layer
-    void *_drop_arg;  // TODO[API-NET]: These two can be merged into one, when API and NET are a single layer
+    void *_arg;
     char *_parameters;
     _z_pending_reply_list_t *_pending_replies;
     z_query_target_t _target;

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -110,10 +110,12 @@ _Z_LIST_DEFINE(_z_session_queryable_rc, _z_session_queryable_rc_t)
 typedef struct _z_reply_t _z_reply_t;
 typedef _z_list_t _z_reply_data_list_t;
 typedef _z_list_t _z_pending_reply_list_t;
+typedef struct _z_reply_rc_t _z_reply_rc_t;
+typedef _z_reply_rc_t z_loaned_reply_t;
 /**
  * The callback signature of the functions handling query replies.
  */
-typedef void (*_z_reply_handler_t)(_z_reply_t *reply, void *arg);
+typedef void (*_z_reply_handler_t)(const z_loaned_reply_t *reply, void *arg);
 
 typedef struct {
     _z_keyexpr_t _key;

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -844,7 +844,7 @@ int8_t z_get(const z_loaned_session_t *zs, z_loaned_keyexpr_t *keyexpr, const ch
 }
 
 _Bool z_reply_is_ok(const z_loaned_reply_t *reply) {
-    (void)(reply);
+    _ZP_UNUSED(reply);
     // For the moment always return TRUE.
     // The support for reply errors will come in the next release.
     return true;
@@ -852,8 +852,8 @@ _Bool z_reply_is_ok(const z_loaned_reply_t *reply) {
 
 const z_loaned_sample_t *z_reply_ok(const z_loaned_reply_t *reply) { return &reply->in->val.data.sample; }
 
-z_value_t z_reply_err(const z_owned_reply_t *reply) {
-    (void)(reply);
+z_value_t z_reply_err(const z_loaned_reply_t *reply) {
+    _ZP_UNUSED(reply);
     return (z_value_t){.payload = _z_bytes_empty(), .encoding = z_encoding_default()};
 }
 #endif

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -443,17 +443,17 @@ OWNED_FUNCTIONS_RC(session)
         return _Z_RES_OK;                                                          \
     }
 
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_sample_t, closure_sample, _z_data_handler_t, _z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_sample_t, closure_owned_sample, _z_owned_sample_handler_t,
-                        _z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_query_t, closure_query, _z_queryable_handler_t, _z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_query_t, closure_owned_query, _z_owned_query_handler_t,
-                        _z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_reply_t, closure_reply, _z_reply_handler_t, _z_dropper_handler_t)
+OWNED_FUNCTIONS_CLOSURE(z_owned_closure_sample_t, closure_sample, _z_data_handler_t, z_dropper_handler_t)
+OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_sample_t, closure_owned_sample, z_owned_sample_handler_t,
+                        z_dropper_handler_t)
+OWNED_FUNCTIONS_CLOSURE(z_owned_closure_query_t, closure_query, _z_queryable_handler_t, z_dropper_handler_t)
+OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_query_t, closure_owned_query, z_owned_query_handler_t,
+                        z_dropper_handler_t)
+OWNED_FUNCTIONS_CLOSURE(z_owned_closure_reply_t, closure_reply, _z_reply_handler_t, z_dropper_handler_t)
 OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_reply_t, closure_owned_reply, z_owned_reply_handler_t,
-                        _z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_hello_t, closure_hello, z_owned_hello_handler_t, _z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_zid_t, closure_zid, z_id_handler_t, _z_dropper_handler_t)
+                        z_dropper_handler_t)
+OWNED_FUNCTIONS_CLOSURE(z_owned_closure_hello_t, closure_hello, z_owned_hello_handler_t, z_dropper_handler_t)
+OWNED_FUNCTIONS_CLOSURE(z_owned_closure_zid_t, closure_zid, z_id_handler_t, z_dropper_handler_t)
 
 /************* Primitives **************/
 typedef struct __z_hello_handler_wrapper_t {
@@ -807,7 +807,7 @@ void z_get_options_default(z_get_options_t *options) {
     options->timeout_ms = Z_GET_TIMEOUT_DEFAULT;
 }
 
-int8_t z_get(const z_loaned_session_t *zs, z_loaned_keyexpr_t *keyexpr, const char *parameters,
+int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, const char *parameters,
              z_owned_closure_reply_t *callback, const z_get_options_t *options) {
     int8_t ret = _Z_RES_OK;
 

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -336,7 +336,13 @@ void z_closure_owned_query_call(const z_owned_closure_owned_query_t *closure, z_
     }
 }
 
-void z_closure_reply_call(const z_owned_closure_reply_t *closure, z_owned_reply_t *reply) {
+void z_closure_reply_call(const z_owned_closure_reply_t *closure, const z_loaned_reply_t *reply) {
+    if (closure->call != NULL) {
+        (closure->call)(reply, closure->context);
+    }
+}
+
+void z_closure_owned_reply_call(const z_owned_closure_owned_reply_t *closure, z_owned_reply_t *reply) {
     if (closure->call != NULL) {
         (closure->call)(reply, closure->context);
     }
@@ -443,7 +449,9 @@ OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_sample_t, closure_owned_sample, _z
 OWNED_FUNCTIONS_CLOSURE(z_owned_closure_query_t, closure_query, _z_queryable_handler_t, _z_dropper_handler_t)
 OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_query_t, closure_owned_query, _z_owned_query_handler_t,
                         _z_dropper_handler_t)
-OWNED_FUNCTIONS_CLOSURE(z_owned_closure_reply_t, closure_reply, z_owned_reply_handler_t, _z_dropper_handler_t)
+OWNED_FUNCTIONS_CLOSURE(z_owned_closure_reply_t, closure_reply, _z_reply_handler_t, _z_dropper_handler_t)
+OWNED_FUNCTIONS_CLOSURE(z_owned_closure_owned_reply_t, closure_owned_reply, z_owned_reply_handler_t,
+                        _z_dropper_handler_t)
 OWNED_FUNCTIONS_CLOSURE(z_owned_closure_hello_t, closure_hello, z_owned_hello_handler_t, _z_dropper_handler_t)
 OWNED_FUNCTIONS_CLOSURE(z_owned_closure_zid_t, closure_zid, z_id_handler_t, _z_dropper_handler_t)
 
@@ -786,7 +794,7 @@ z_owned_keyexpr_t z_publisher_keyexpr(z_loaned_publisher_t *publisher) {
 #endif
 
 #if Z_FEATURE_QUERY == 1
-OWNED_FUNCTIONS_PTR(_z_reply_t, reply, _z_owner_noop_copy, _z_reply_free)
+OWNED_FUNCTIONS_RC(reply)
 
 void z_get_options_default(z_get_options_t *options) {
     options->target = z_query_target_default();
@@ -835,14 +843,14 @@ int8_t z_get(const z_loaned_session_t *zs, z_loaned_keyexpr_t *keyexpr, const ch
     return ret;
 }
 
-_Bool z_reply_is_ok(const z_owned_reply_t *reply) {
+_Bool z_reply_is_ok(const z_loaned_reply_t *reply) {
     (void)(reply);
     // For the moment always return TRUE.
     // The support for reply errors will come in the next release.
     return true;
 }
 
-const z_loaned_sample_t *z_reply_ok(const z_owned_reply_t *reply) { return &reply->_val->data.sample; }
+const z_loaned_sample_t *z_reply_ok(const z_loaned_reply_t *reply) { return &reply->in->val.data.sample; }
 
 z_value_t z_reply_err(const z_owned_reply_t *reply) {
     (void)(reply);

--- a/src/api/handlers.c
+++ b/src/api/handlers.c
@@ -45,6 +45,9 @@ void _z_owned_query_move(z_owned_query_t *dst, z_owned_query_t *src) {
 
 z_owned_query_t *_z_query_to_owned_ptr(const z_loaned_query_t *src) {
     z_owned_query_t *dst = (z_owned_query_t *)zp_malloc(sizeof(z_owned_query_t));
+    if (dst == NULL) {
+        return NULL;
+    }
     _z_query_rc_copy(&dst->_rc, src);
     return dst;
 }
@@ -57,17 +60,12 @@ void _z_owned_reply_move(z_owned_reply_t *dst, z_owned_reply_t *src) {
     zp_free(src);
 }
 
-z_owned_reply_t *_z_reply_clone(const z_owned_reply_t *src) {
+z_owned_reply_t *_z_reply_to_owned_ptr(const z_loaned_reply_t *src) {
     z_owned_reply_t *dst = (z_owned_reply_t *)zp_malloc(sizeof(z_owned_reply_t));
     if (dst == NULL) {
         return NULL;
     }
-    if (src != NULL && src->_val) {
-        dst->_val = (_z_reply_t *)zp_malloc(sizeof(_z_reply_t));
-        _z_reply_copy(dst->_val, src->_val);
-    } else {
-        dst->_val = NULL;
-    }
+    _z_reply_rc_copy(&dst->_rc, src);
     return dst;
 }
 #endif  // Z_FEATURE_QUERY

--- a/src/api/handlers.c
+++ b/src/api/handlers.c
@@ -28,10 +28,10 @@ z_owned_sample_t *_z_sample_to_owned_ptr(const z_loaned_sample_t *src) {
     if (dst == NULL) {
         return NULL;
     }
-    if (src != NULL) {
-        dst->_rc = _z_sample_rc_clone(src);
-    } else {
+    if (src == NULL) {
         dst->_rc.in = NULL;
+    } else {
+        _z_sample_rc_copy(&dst->_rc, src);
     }
     return dst;
 }
@@ -48,7 +48,11 @@ z_owned_query_t *_z_query_to_owned_ptr(const z_loaned_query_t *src) {
     if (dst == NULL) {
         return NULL;
     }
-    _z_query_rc_copy(&dst->_rc, src);
+    if (src == NULL) {
+        dst->_rc.in = NULL;
+    } else {
+        _z_query_rc_copy(&dst->_rc, src);
+    }
     return dst;
 }
 #endif  // Z_FEATURE_QUERYABLE
@@ -65,7 +69,11 @@ z_owned_reply_t *_z_reply_to_owned_ptr(const z_loaned_reply_t *src) {
     if (dst == NULL) {
         return NULL;
     }
-    _z_reply_rc_copy(&dst->_rc, src);
+    if (src == NULL) {
+        dst->_rc.in = NULL;
+    } else {
+        _z_reply_rc_copy(&dst->_rc, src);
+    }
     return dst;
 }
 #endif  // Z_FEATURE_QUERY

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -383,7 +383,7 @@ int8_t _z_send_reply(const _z_query_t *query, _z_keyexpr_t keyexpr, const _z_val
 /*------------------ Query ------------------*/
 int8_t _z_query(_z_session_t *zn, _z_keyexpr_t keyexpr, const char *parameters, const z_query_target_t target,
                 const z_consolidation_mode_t consolidation, _z_value_t value, _z_reply_handler_t callback,
-                void *arg_call, _z_drop_handler_t dropper, void *arg_drop, uint32_t timeout_ms
+                _z_drop_handler_t dropper, void *arg, uint32_t timeout_ms
 #if Z_FEATURE_ATTACHMENT == 1
                 ,
                 z_attachment_t attachment
@@ -403,8 +403,7 @@ int8_t _z_query(_z_session_t *zn, _z_keyexpr_t keyexpr, const char *parameters, 
         pq->_callback = callback;
         pq->_dropper = dropper;
         pq->_pending_replies = NULL;
-        pq->_call_arg = arg_call;
-        pq->_drop_arg = arg_drop;
+        pq->_arg = arg;
 
         ret = _z_register_pending_query(zn, pq);  // Add the pending query to the current session
         if (ret == _Z_RES_OK) {

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -107,9 +107,9 @@ _z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, 
     return reply;
 }
 #else
-_z_reply_t _z_reply_create(const _z_keyexpr_t *keyexpr, z_reply_tag_t tag, z_id_t id, const _z_bytes_t *payload,
-                           const _z_timestamp_t *timestamp, const _z_encoding_t encoding, const z_sample_kind_t kind,
-                           const z_attachment_t att) {
+_z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, const _z_bytes_t *payload,
+                           const _z_timestamp_t *timestamp, _z_encoding_t encoding, z_sample_kind_t kind,
+                           z_attachment_t att) {
     _ZP_UNUSED(keyexpr);
     _ZP_UNUSED(tag);
     _ZP_UNUSED(id);

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -20,7 +20,7 @@
 _z_reply_t _z_reply_null(void) {
     _z_reply_t r = {._tag = Z_REPLY_TAG_DATA,
                     .data = {
-                        .replier_id = 0,
+                        .replier_id = {.id = {0}},
                         .sample = {.in = NULL},
                     }};
     return r;

--- a/src/net/reply.c
+++ b/src/net/reply.c
@@ -13,8 +13,18 @@
 
 #include "zenoh-pico/net/reply.h"
 
+#include "zenoh-pico/net/sample.h"
 #include "zenoh-pico/session/utils.h"
 #include "zenoh-pico/utils/logging.h"
+
+_z_reply_t _z_reply_null(void) {
+    _z_reply_t r = {._tag = Z_REPLY_TAG_DATA,
+                    .data = {
+                        .replier_id = 0,
+                        .sample = {.in = NULL},
+                    }};
+    return r;
+}
 
 #if Z_FEATURE_QUERY == 1
 void _z_reply_data_clear(_z_reply_data_t *reply_data) {
@@ -38,12 +48,9 @@ void _z_reply_data_copy(_z_reply_data_t *dst, _z_reply_data_t *src) {
     dst->replier_id = src->replier_id;
 }
 
-_z_reply_t *_z_reply_alloc_and_move(_z_reply_t *_reply) {
-    _z_reply_t *reply = (_z_reply_t *)z_malloc(sizeof(_z_reply_t));
-    if (reply != NULL) {
-        *reply = *_reply;
-        (void)memset(_reply, 0, sizeof(_z_reply_t));
-    }
+_z_reply_t _z_reply_move(_z_reply_t *src_reply) {
+    _z_reply_t reply = *src_reply;
+    *src_reply = _z_reply_null();
     return reply;
 }
 
@@ -75,5 +82,42 @@ void _z_pending_reply_clear(_z_pending_reply_t *pr) {
 
     // Free the timestamp
     _z_timestamp_clear(&pr->_tstamp);
+}
+
+_z_reply_t _z_reply_create(_z_keyexpr_t keyexpr, z_reply_tag_t tag, _z_id_t id, const _z_bytes_t *payload,
+                           const _z_timestamp_t *timestamp, _z_encoding_t encoding, z_sample_kind_t kind,
+                           z_attachment_t att) {
+    _z_reply_t reply = _z_reply_null();
+    reply._tag = tag;
+    if (tag == Z_REPLY_TAG_DATA) {
+        reply.data.replier_id = id;
+        // Create sample
+        _z_sample_t sample = _z_sample_null();
+        sample.keyexpr = keyexpr;    // FIXME: call z_keyexpr_move or copy
+        sample.encoding = encoding;  // FIXME: call z_encoding_move or copy
+        _z_bytes_copy(&sample.payload, payload);
+        sample.kind = kind;
+        sample.timestamp = _z_timestamp_duplicate(timestamp);
+#if Z_FEATURE_ATTACHMENT == 1
+        sample.attachment = att;  // FIXME: call z_attachment_move or copy
+#endif
+        // Create sample rc from value
+        reply.data.sample = _z_sample_rc_new_from_val(sample);
+    }
+    return reply;
+}
+#else
+_z_reply_t _z_reply_create(const _z_keyexpr_t *keyexpr, z_reply_tag_t tag, z_id_t id, const _z_bytes_t *payload,
+                           const _z_timestamp_t *timestamp, const _z_encoding_t encoding, const z_sample_kind_t kind,
+                           const z_attachment_t att) {
+    _ZP_UNUSED(keyexpr);
+    _ZP_UNUSED(tag);
+    _ZP_UNUSED(id);
+    _ZP_UNUSED(payload);
+    _ZP_UNUSED(timestamp);
+    _ZP_UNUSED(encoding);
+    _ZP_UNUSED(kind);
+    _ZP_UNUSED(att);
+    return _z_reply_null();
 }
 #endif

--- a/src/session/query.c
+++ b/src/session/query.c
@@ -27,14 +27,10 @@
 #if Z_FEATURE_QUERY == 1
 void _z_pending_query_clear(_z_pending_query_t *pen_qry) {
     if (pen_qry->_dropper != NULL) {
-        pen_qry->_dropper(pen_qry->_drop_arg);
+        pen_qry->_dropper(pen_qry->_arg);
     }
-
-    z_free(pen_qry->_call_arg);
-
     _z_keyexpr_clear(&pen_qry->_key);
     _z_str_clear(pen_qry->_parameters);
-
     _z_pending_reply_list_free(&pen_qry->_pending_replies);
 }
 
@@ -181,7 +177,7 @@ int8_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, cons
 
     // Trigger the user callback
     if ((ret == _Z_RES_OK) && (pen_qry->_consolidation != Z_CONSOLIDATION_MODE_LATEST)) {
-        pen_qry->_callback(_z_reply_alloc_and_move(&reply), pen_qry->_call_arg);
+        pen_qry->_callback(_z_reply_alloc_and_move(&reply), pen_qry->_arg);
     }
 
     if (ret != _Z_RES_OK) {
@@ -208,7 +204,7 @@ int8_t _z_trigger_query_reply_final(_z_session_t *zn, _z_zint_t id) {
             _z_pending_reply_t *pen_rep = _z_pending_reply_list_head(pen_qry->_pending_replies);
 
             // Trigger the query handler
-            pen_qry->_callback(_z_reply_alloc_and_move(&pen_rep->_reply), pen_qry->_call_arg);
+            pen_qry->_callback(_z_reply_alloc_and_move(&pen_rep->_reply), pen_qry->_arg);
             pen_qry->_pending_replies = _z_pending_reply_list_pop(pen_qry->_pending_replies, NULL);
         }
     }

--- a/src/session/query.c
+++ b/src/session/query.c
@@ -113,19 +113,15 @@ int8_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, cons
         ret = _Z_ERR_QUERY_NOT_MATCH;
     }
 
-    // Build the reply
-    _z_reply_t reply;
-    reply._tag = Z_REPLY_TAG_DATA;
-    reply.data.replier_id = zn->_local_zid;
-    reply.data.sample.in->val.keyexpr = expanded_ke;
-    _z_bytes_copy(&reply.data.sample.in->val.payload, &msg->_payload);
-    reply.data.sample.in->val.encoding.id = msg->_encoding.id;
-    _z_bytes_copy(&reply.data.sample.in->val.encoding.schema, &msg->_encoding.schema);
-    reply.data.sample.in->val.kind = Z_SAMPLE_KIND_PUT;
-    reply.data.sample.in->val.timestamp = _z_timestamp_duplicate(&msg->_commons._timestamp);
+    // Retrieve attachment
 #if Z_FEATURE_ATTACHMENT == 1
-    reply.data.sample.in->val.attachment = _z_encoded_as_attachment(&msg->_attachment);
+    z_attachment_t att = _z_encoded_as_attachment(&msg->_attachment);
+#else
+    z_attachment_t att = z_attachment_null();
 #endif
+    // Build the reply
+    _z_reply_t reply = _z_reply_create(expanded_ke, Z_REPLY_TAG_DATA, zn->_local_zid, &msg->_payload,
+                                       &msg->_commons._timestamp, msg->_encoding, Z_SAMPLE_KIND_PUT, att);
 
     // Verify if this is a newer reply, free the old one in case it is
     if ((ret == _Z_RES_OK) && ((pen_qry->_consolidation == Z_CONSOLIDATION_MODE_LATEST) ||
@@ -147,7 +143,6 @@ int8_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, cons
                 }
                 break;
             }
-
             pen_rps = _z_pending_reply_list_tail(pen_rps);
         }
 
@@ -177,7 +172,10 @@ int8_t _z_trigger_query_reply_partial(_z_session_t *zn, const _z_zint_t id, cons
 
     // Trigger the user callback
     if ((ret == _Z_RES_OK) && (pen_qry->_consolidation != Z_CONSOLIDATION_MODE_LATEST)) {
-        pen_qry->_callback(_z_reply_alloc_and_move(&reply), pen_qry->_arg);
+        _z_reply_rc_t cb_reply = _z_reply_rc_new();
+        cb_reply.in->val = _z_reply_move(&reply);
+        pen_qry->_callback(&cb_reply, pen_qry->_arg);
+        _z_reply_rc_drop(&cb_reply);
     }
 
     if (ret != _Z_RES_OK) {
@@ -204,8 +202,11 @@ int8_t _z_trigger_query_reply_final(_z_session_t *zn, _z_zint_t id) {
             _z_pending_reply_t *pen_rep = _z_pending_reply_list_head(pen_qry->_pending_replies);
 
             // Trigger the query handler
-            pen_qry->_callback(_z_reply_alloc_and_move(&pen_rep->_reply), pen_qry->_arg);
+            _z_reply_rc_t cb_reply = _z_reply_rc_new();
+            cb_reply.in->val = _z_reply_move(&pen_rep->_reply);
+            pen_qry->_callback(&cb_reply, pen_qry->_arg);
             pen_qry->_pending_replies = _z_pending_reply_list_pop(pen_qry->_pending_replies, NULL);
+            _z_reply_rc_drop(&cb_reply);
         }
     }
 

--- a/tests/z_api_alignment_test.c
+++ b/tests/z_api_alignment_test.c
@@ -88,7 +88,7 @@ void query_handler(const z_loaned_query_t *query, void *arg) {
 }
 
 volatile unsigned int replies = 0;
-void reply_handler(z_owned_reply_t *reply, void *arg) {
+void reply_handler(const z_loaned_reply_t *reply, void *arg) {
     printf("%s\n", __func__);
     replies++;
 
@@ -107,9 +107,6 @@ void reply_handler(z_owned_reply_t *reply, void *arg) {
         z_value_t _ret_zvalue = z_reply_err(reply);
         (void)(_ret_zvalue);
     }
-
-    z_null(reply);
-    z_drop(reply);  // validate double-drop safety: caller drops reply if it's not dropped by the handler
 }
 
 volatile unsigned int datas = 0;

--- a/tests/z_client_test.c
+++ b/tests/z_client_test.c
@@ -69,7 +69,7 @@ void query_handler(const z_loaned_query_t *query, void *arg) {
 }
 
 volatile unsigned int replies = 0;
-void reply_handler(z_owned_reply_t *reply, void *arg) {
+void reply_handler(const z_loaned_reply_t *reply, void *arg) {
     char *res = (char *)malloc(64);
     snprintf(res, 64, "%s%u", uri, *(unsigned int *)arg);
     if (z_reply_is_ok(reply)) {

--- a/tests/z_perf_rx.c
+++ b/tests/z_perf_rx.c
@@ -124,6 +124,7 @@ int main(int argc, char **argv) {
 }
 #else
 int main(void) {
+    (void)test_stats;
     printf("ERROR: Zenoh pico was compiled without Z_FEATURE_SUBSCRIPTION but this test requires it.\n");
     return -2;
 }


### PR DESCRIPTION
Similarly to what I did on sample and queries, this switch replies to a rc so they can be easily used out of the callback context.

@sashacmc if you can review this.