### PR TITLE
Fix some string rework issues

### DIFF
--- a/include/zenoh-pico/link/endpoint.h
+++ b/include/zenoh-pico/link/endpoint.h
@@ -49,8 +49,7 @@ typedef struct {
 _Bool _z_locator_eq(const _z_locator_t *left, const _z_locator_t *right);
 
 void _z_locator_init(_z_locator_t *locator);
-char *_z_locator_to_string(const _z_locator_t *l);
-_z_string_t *_z_locator_to_zstring(const _z_locator_t *loc);
+_z_string_t *_z_locator_to_string(const _z_locator_t *loc);
 int8_t _z_locator_from_str(_z_locator_t *lc, const char *s);
 
 size_t _z_locator_size(_z_locator_t *lc);

--- a/include/zenoh-pico/link/endpoint.h
+++ b/include/zenoh-pico/link/endpoint.h
@@ -50,6 +50,7 @@ _Bool _z_locator_eq(const _z_locator_t *left, const _z_locator_t *right);
 
 void _z_locator_init(_z_locator_t *locator);
 char *_z_locator_to_str(const _z_locator_t *l);
+_z_string_t *_z_locator_to_zstring(const _z_locator_t *loc);
 int8_t _z_locator_from_str(_z_locator_t *lc, const char *s);
 
 size_t _z_locator_size(_z_locator_t *lc);

--- a/include/zenoh-pico/link/endpoint.h
+++ b/include/zenoh-pico/link/endpoint.h
@@ -49,7 +49,7 @@ typedef struct {
 _Bool _z_locator_eq(const _z_locator_t *left, const _z_locator_t *right);
 
 void _z_locator_init(_z_locator_t *locator);
-char *_z_locator_to_str(const _z_locator_t *l);
+char *_z_locator_to_string(const _z_locator_t *l);
 _z_string_t *_z_locator_to_zstring(const _z_locator_t *loc);
 int8_t _z_locator_from_str(_z_locator_t *lc, const char *s);
 

--- a/include/zenoh-pico/protocol/codec/core.h
+++ b/include/zenoh-pico/protocol/codec/core.h
@@ -72,6 +72,7 @@ int8_t _z_bytes_decode(_z_bytes_t *bs, _z_zbuf_t *buf);
 int8_t _z_zbuf_read_exact(_z_zbuf_t *zbf, uint8_t *dest, size_t length);
 
 int8_t _z_str_encode(_z_wbuf_t *buf, const char *s);
+int8_t _z_zstr_encode(_z_wbuf_t *wbf, const _z_string_t *s);
 int8_t _z_str_decode(char **str, _z_zbuf_t *buf);
 
 size_t _z_encoding_len(const _z_encoding_t *en);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -825,15 +825,14 @@ int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, co
             opt.consolidation.mode = Z_CONSOLIDATION_MODE_LATEST;
         }
     }
-    _z_value_t value;
+    // Set value
+    _z_value_t value = {.payload = _z_bytes_empty(), .encoding = opt.encoding};
     if (opt.payload != NULL) {
         z_loaned_bytes_t *loaned_payload = z_bytes_loan_mut(opt.payload);
         value.payload =
             (loaned_payload != NULL) ? _z_bytes_wrap(loaned_payload->start, loaned_payload->len) : _z_bytes_empty();
-        value.encoding = opt.encoding;
-    } else {
-        value.payload = _z_bytes_empty();
     }
+
     ret = _z_query(&_Z_RC_IN_VAL(zs), *keyexpr, parameters, opt.target, opt.consolidation.mode, value, callback->call,
                    callback->drop, ctx, opt.timeout_ms
 #if Z_FEATURE_ATTACHMENT == 1
@@ -919,15 +918,14 @@ int8_t z_query_reply(const z_loaned_query_t *query, const z_loaned_keyexpr_t *ke
     } else {
         opts = *options;
     }
-    _z_value_t value;
+    // Set value
+    _z_value_t value = {.payload = _z_bytes_empty(), .encoding = opts.encoding};;
     if (payload != NULL) {
         z_loaned_bytes_t *loaned_payload = z_bytes_loan_mut(payload);
         value.payload =
             (loaned_payload != NULL) ? _z_bytes_wrap(loaned_payload->start, loaned_payload->len) : _z_bytes_empty();
-        value.encoding = opts.encoding;
-    } else {
-        value.payload = _z_bytes_empty();
     }
+    
     int8_t ret = _z_send_reply(&query->in->val, *keyexpr, value, Z_SAMPLE_KIND_PUT, opts.attachment);
     if (payload != NULL) {
         z_bytes_drop(payload);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -919,13 +919,13 @@ int8_t z_query_reply(const z_loaned_query_t *query, const z_loaned_keyexpr_t *ke
         opts = *options;
     }
     // Set value
-    _z_value_t value = {.payload = _z_bytes_empty(), .encoding = opts.encoding};;
+    _z_value_t value = {.payload = _z_bytes_empty(), .encoding = opts.encoding};
     if (payload != NULL) {
         z_loaned_bytes_t *loaned_payload = z_bytes_loan_mut(payload);
         value.payload =
             (loaned_payload != NULL) ? _z_bytes_wrap(loaned_payload->start, loaned_payload->len) : _z_bytes_empty();
     }
-    
+
     int8_t ret = _z_send_reply(&query->in->val, *keyexpr, value, Z_SAMPLE_KIND_PUT, opts.attachment);
     if (payload != NULL) {
         z_bytes_drop(payload);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -406,6 +406,14 @@ OWNED_FUNCTIONS_PTR(_z_string_vec_t, string_array, _z_owner_noop_copy, _z_string
 VIEW_FUNCTIONS_PTR(_z_string_vec_t, string_array)
 OWNED_FUNCTIONS_PTR(_z_bytes_t, bytes, _z_bytes_copy, _z_bytes_free)
 
+static _z_bytes_t _z_bytes_from_owned_bytes(z_owned_bytes_t *bytes) {
+    _z_bytes_t b = _z_bytes_empty();
+    if ((bytes != NULL) && (bytes->_val != NULL)) {
+        b = _z_bytes_wrap(bytes->_val->start, bytes->_val->len);
+    }
+    return b;
+}
+
 OWNED_FUNCTIONS_RC(sample)
 // TODO(sashacmc): drop != close
 OWNED_FUNCTIONS_RC(session)
@@ -826,12 +834,7 @@ int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, co
         }
     }
     // Set value
-    _z_value_t value = {.payload = _z_bytes_empty(), .encoding = opt.encoding};
-    if (opt.payload != NULL) {
-        z_loaned_bytes_t *loaned_payload = z_bytes_loan_mut(opt.payload);
-        value.payload =
-            (loaned_payload != NULL) ? _z_bytes_wrap(loaned_payload->start, loaned_payload->len) : _z_bytes_empty();
-    }
+    _z_value_t value = {.payload = _z_bytes_from_owned_bytes(opt.payload), .encoding = opt.encoding};
 
     ret = _z_query(&_Z_RC_IN_VAL(zs), *keyexpr, parameters, opt.target, opt.consolidation.mode, value, callback->call,
                    callback->drop, ctx, opt.timeout_ms
@@ -919,12 +922,7 @@ int8_t z_query_reply(const z_loaned_query_t *query, const z_loaned_keyexpr_t *ke
         opts = *options;
     }
     // Set value
-    _z_value_t value = {.payload = _z_bytes_empty(), .encoding = opts.encoding};
-    if (payload != NULL) {
-        z_loaned_bytes_t *loaned_payload = z_bytes_loan_mut(payload);
-        value.payload =
-            (loaned_payload != NULL) ? _z_bytes_wrap(loaned_payload->start, loaned_payload->len) : _z_bytes_empty();
-    }
+    _z_value_t value = {.payload = _z_bytes_from_owned_bytes(payload), .encoding = opts.encoding};
 
     int8_t ret = _z_send_reply(&query->in->val, *keyexpr, value, Z_SAMPLE_KIND_PUT, opts.attachment);
     if (payload != NULL) {

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -791,9 +791,7 @@ void z_get_options_default(z_get_options_t *options) {
     options->target = z_query_target_default();
     options->consolidation = z_query_consolidation_default();
     options->encoding = z_encoding_default();
-    // TODO(sashacmc): add cleanup or rework to on stack
-    options->payload = (z_owned_bytes_t *)z_malloc(sizeof(z_owned_bytes_t));
-    z_bytes_null(options->payload);
+    options->payload = NULL;
 #if Z_FEATURE_ATTACHMENT == 1
     options->attachment = z_attachment_null();
 #endif
@@ -827,10 +825,15 @@ int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, co
             opt.consolidation.mode = Z_CONSOLIDATION_MODE_LATEST;
         }
     }
-    z_loaned_bytes_t *loaned_payload = z_bytes_loan_mut(opt.payload);
-    _z_value_t value = {
-        .payload = loaned_payload ? _z_bytes_wrap(loaned_payload->start, loaned_payload->len) : _z_bytes_empty(),
-        .encoding = opt.encoding};
+    _z_value_t value;
+    if (opt.payload != NULL) {
+        z_loaned_bytes_t *loaned_payload = z_bytes_loan_mut(opt.payload);
+        value.payload =
+            (loaned_payload != NULL) ? _z_bytes_wrap(loaned_payload->start, loaned_payload->len) : _z_bytes_empty();
+        value.encoding = opt.encoding;
+    } else {
+        value.payload = _z_bytes_empty();
+    }
     ret = _z_query(&_Z_RC_IN_VAL(zs), *keyexpr, parameters, opt.target, opt.consolidation.mode, value, callback->call,
                    callback->drop, ctx, opt.timeout_ms
 #if Z_FEATURE_ATTACHMENT == 1
@@ -838,7 +841,9 @@ int8_t z_get(const z_loaned_session_t *zs, const z_loaned_keyexpr_t *keyexpr, co
                    opt.attachment
 #endif
     );
-    z_bytes_drop(opt.payload);
+    if (opt.payload != NULL) {
+        z_bytes_drop(opt.payload);
+    }
     return ret;
 }
 
@@ -914,12 +919,19 @@ int8_t z_query_reply(const z_loaned_query_t *query, const z_loaned_keyexpr_t *ke
     } else {
         opts = *options;
     }
-    z_loaned_bytes_t *loaned_payload = z_bytes_loan_mut(payload);
-    _z_value_t value = {
-        .payload = loaned_payload ? _z_bytes_wrap(loaned_payload->start, loaned_payload->len) : _z_bytes_empty(),
-        .encoding = {.id = opts.encoding.id, .schema = opts.encoding.schema}};
+    _z_value_t value;
+    if (payload != NULL) {
+        z_loaned_bytes_t *loaned_payload = z_bytes_loan_mut(payload);
+        value.payload =
+            (loaned_payload != NULL) ? _z_bytes_wrap(loaned_payload->start, loaned_payload->len) : _z_bytes_empty();
+        value.encoding = opts.encoding;
+    } else {
+        value.payload = _z_bytes_empty();
+    }
     int8_t ret = _z_send_reply(&query->in->val, *keyexpr, value, Z_SAMPLE_KIND_PUT, opts.attachment);
-    z_bytes_drop(payload);
+    if (payload != NULL) {
+        z_bytes_drop(payload);
+    }
     return ret;
 }
 #endif

--- a/src/link/endpoint.c
+++ b/src/link/endpoint.c
@@ -254,7 +254,7 @@ void __z_locator_onto_str(char *dst, size_t dst_len, const _z_locator_t *loc) {
  * Returns:
  *   The pointer to the stringified :c:type:`_z_locator_t`.
  */
-char *_z_locator_to_str(const _z_locator_t *l) {
+char *_z_locator_to_string(const _z_locator_t *l) {
     size_t len = _z_locator_strlen(l) + (size_t)1;
     char *dst = (char *)z_malloc(len);
     if (dst != NULL) {
@@ -438,7 +438,7 @@ int8_t _z_endpoint_from_str(_z_endpoint_t *ep, const char *str) {
 char *_z_endpoint_to_str(const _z_endpoint_t *endpoint) {
     char *ret = NULL;
 
-    char *locator = _z_locator_to_str(&endpoint->_locator);
+    char *locator = _z_locator_to_string(&endpoint->_locator);
     if (locator != NULL) {
         size_t len = 1;  // Start with space for the null-terminator
         len = len + strlen(locator);

--- a/src/link/endpoint.c
+++ b/src/link/endpoint.c
@@ -263,6 +263,26 @@ char *_z_locator_to_str(const _z_locator_t *l) {
     return dst;
 }
 
+/**
+ * Converts a :c:type:`_z_locator_t` into its _z_string format.
+ *
+ * Parameters:
+ *   loc: :c:type:`_z_locator_t` to be converted into its _z_string format.
+ *
+ * Returns:
+ *   The pointer to the z_stringified :c:type:`_z_locator_t`.
+ */
+_z_string_t *_z_locator_to_zstring(const _z_locator_t *loc) {
+    _z_string_t *s = (_z_string_t *)z_malloc(sizeof(_z_string_t));
+    s->len = _z_locator_strlen(loc) + (size_t)1;
+    s->val = (char *)z_malloc(s->len);
+    if (s->val == NULL) {
+        return NULL;
+    }
+    __z_locator_onto_str(s->val, s->len, loc);
+    return s;
+}
+
 /*------------------ Endpoint ------------------*/
 void _z_endpoint_init(_z_endpoint_t *endpoint) {
     _z_locator_init(&endpoint->_locator);

--- a/src/protocol/codec.c
+++ b/src/protocol/codec.c
@@ -259,6 +259,13 @@ int8_t _z_str_encode(_z_wbuf_t *wbf, const char *s) {
     return _z_wbuf_write_bytes(wbf, (const uint8_t *)s, 0, len);
 }
 
+int8_t _z_zstr_encode(_z_wbuf_t *wbf, const _z_string_t *s) {
+    size_t len = s->len - (size_t)1;
+    _Z_RETURN_IF_ERR(_z_zsize_encode(wbf, len))
+    // Note that this does not put the string terminator on the wire.
+    return _z_wbuf_write_bytes(wbf, (const uint8_t *)s->val, 0, len);
+}
+
 int8_t _z_str_decode(char **str, _z_zbuf_t *zbf) {
     int8_t ret = _Z_RES_OK;
 

--- a/src/protocol/codec/message.c
+++ b/src/protocol/codec/message.c
@@ -148,7 +148,7 @@ int8_t _z_locators_encode(_z_wbuf_t *wbf, const _z_locator_array_t *la) {
     _Z_DEBUG("Encoding _LOCATORS");
     _Z_RETURN_IF_ERR(_z_zsize_encode(wbf, la->_len))
     for (size_t i = 0; i < la->_len; i++) {
-        char *s = _z_locator_to_str(&la->_val[i]);
+        char *s = _z_locator_to_string(&la->_val[i]);
         _Z_RETURN_IF_ERR(_z_str_encode(wbf, s))
         z_free(s);
     }

--- a/src/protocol/codec/message.c
+++ b/src/protocol/codec/message.c
@@ -148,8 +148,8 @@ int8_t _z_locators_encode(_z_wbuf_t *wbf, const _z_locator_array_t *la) {
     _Z_DEBUG("Encoding _LOCATORS");
     _Z_RETURN_IF_ERR(_z_zsize_encode(wbf, la->_len))
     for (size_t i = 0; i < la->_len; i++) {
-        char *s = _z_locator_to_string(&la->_val[i]);
-        _Z_RETURN_IF_ERR(_z_str_encode(wbf, s))
+        _z_string_t *s = _z_locator_to_string(&la->_val[i]);
+        _Z_RETURN_IF_ERR(_z_zstr_encode(wbf, s))
         z_free(s);
     }
 

--- a/src/session/scout.c
+++ b/src/session/scout.c
@@ -86,9 +86,9 @@ _z_hello_list_t *__z_scout_loop(const _z_wbuf_t *wbf, const char *locator, unsig
                                 if (n_loc > 0) {
                                     hello->locators = _z_string_vec_make(n_loc);
                                     for (size_t i = 0; i < n_loc; i++) {
-                                        _z_string_vec_append(&hello->locators,
-                                                             _z_locator_to_zstring(
-                                                                 &s_msg._body._hello._locators._val[i]));
+                                        _z_string_vec_append(
+                                            &hello->locators,
+                                            _z_locator_to_zstring(&s_msg._body._hello._locators._val[i]));
                                     }
                                 } else {
                                     // @TODO: construct the locator departing from the sock address

--- a/src/session/scout.c
+++ b/src/session/scout.c
@@ -88,7 +88,7 @@ _z_hello_list_t *__z_scout_loop(const _z_wbuf_t *wbf, const char *locator, unsig
                                     for (size_t i = 0; i < n_loc; i++) {
                                         _z_string_vec_append(
                                             &hello->locators,
-                                            _z_locator_to_zstring(&s_msg._body._hello._locators._val[i]));
+                                            _z_locator_to_string(&s_msg._body._hello._locators._val[i]));
                                     }
                                 } else {
                                     // @TODO: construct the locator departing from the sock address

--- a/src/session/scout.c
+++ b/src/session/scout.c
@@ -87,8 +87,8 @@ _z_hello_list_t *__z_scout_loop(const _z_wbuf_t *wbf, const char *locator, unsig
                                     hello->locators = _z_string_vec_make(n_loc);
                                     for (size_t i = 0; i < n_loc; i++) {
                                         _z_string_vec_append(&hello->locators,
-                                                             _z_string_make_as_ptr(_z_locator_to_str(
-                                                                 &s_msg._body._hello._locators._val[i])));
+                                                             _z_locator_to_zstring(
+                                                                 &s_msg._body._hello._locators._val[i]));
                                     }
                                 } else {
                                     // @TODO: construct the locator departing from the sock address

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -331,10 +331,10 @@ void assert_eq_locator_array(const _z_locator_array_t *left, const _z_locator_ar
         const _z_locator_t *l = &left->_val[i];
         const _z_locator_t *r = &right->_val[i];
 
-        char *ls = _z_locator_to_string(l);
-        char *rs = _z_locator_to_string(r);
+        _z_string_t *ls = _z_locator_to_string(l);
+        _z_string_t *rs = _z_locator_to_string(r);
 
-        printf("%s:%s", ls, rs);
+        printf("%s:%s", ls->val, rs->val);
         if (i < left->_len - 1) printf(" ");
 
         z_free(ls);

--- a/tests/z_msgcodec_test.c
+++ b/tests/z_msgcodec_test.c
@@ -331,8 +331,8 @@ void assert_eq_locator_array(const _z_locator_array_t *left, const _z_locator_ar
         const _z_locator_t *l = &left->_val[i];
         const _z_locator_t *r = &right->_val[i];
 
-        char *ls = _z_locator_to_str(l);
-        char *rs = _z_locator_to_str(r);
+        char *ls = _z_locator_to_string(l);
+        char *rs = _z_locator_to_string(r);
 
         printf("%s:%s", ls, rs);
         if (i < left->_len - 1) printf(" ");


### PR DESCRIPTION
There was a memory leak in locator with a double allocation, added a function to convert locator to z_string to avoid that.

Proposal to use NULL pointer as default value for query/reply `value`