### PR TITLE
Activate resource declaration for p2p unicast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           CMAKE_GENERATOR=Ninja ASAN=ON make BUILD_TYPE=Debug test
 
   run_windows_test:
-    name: Run unit tests on windows-latest
+    name: Run peer unicast test on windows-latest
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -45,6 +45,7 @@ jobs:
         run: |
           make all
           .\build\tests\Debug\z_test_unicast.exe
+        timeout-minutes: 10
         shell: cmd
         env: 
           Z_FEATURE_UNSTABLE_API: 1

--- a/include/zenoh-pico/net/filtering.h
+++ b/include/zenoh-pico/net/filtering.h
@@ -41,9 +41,8 @@ void _z_filter_target_elem_free(void **elem);
 _Z_LIST_DEFINE(_z_filter_target, _z_filter_target_t)
 
 typedef enum {
-    WRITE_FILTER_INIT = 0,
-    WRITE_FILTER_ACTIVE = 1,
-    WRITE_FILTER_OFF = 2,
+    WRITE_FILTER_ACTIVE = 0,
+    WRITE_FILTER_OFF = 1,
 } _z_write_filter_state_t;
 
 typedef struct {

--- a/include/zenoh-pico/session/interest.h
+++ b/include/zenoh-pico/session/interest.h
@@ -38,6 +38,7 @@ z_result_t _z_interest_process_undeclares(_z_session_t *zn, const _z_declaration
 z_result_t _z_interest_process_declare_final(_z_session_t *zn, uint32_t id, _z_transport_peer_common_t *peer);
 z_result_t _z_interest_process_interest_final(_z_session_t *zn, uint32_t id);
 z_result_t _z_interest_process_interest(_z_session_t *zn, _z_keyexpr_t key, uint32_t id, uint8_t flags);
+z_result_t _z_interest_push_declarations_to_peer(_z_session_t *zn, _z_transport_peer_common_t *peer);
 void _z_interest_peer_disconnected(_z_session_t *zn, _z_transport_peer_common_t *peer);
 
 #ifdef __cplusplus

--- a/include/zenoh-pico/session/interest.h
+++ b/include/zenoh-pico/session/interest.h
@@ -40,6 +40,7 @@ z_result_t _z_interest_process_interest_final(_z_session_t *zn, uint32_t id);
 z_result_t _z_interest_process_interest(_z_session_t *zn, _z_keyexpr_t key, uint32_t id, uint8_t flags);
 z_result_t _z_interest_push_declarations_to_peer(_z_session_t *zn, _z_transport_peer_common_t *peer);
 void _z_interest_peer_disconnected(_z_session_t *zn, _z_transport_peer_common_t *peer);
+void _z_interest_replay_declare(_z_session_t *zn, _z_session_interest_t *interest);
 
 #ifdef __cplusplus
 }

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -112,8 +112,8 @@ void _z_session_queryable_clear(_z_session_queryable_t *res);
 _Z_REFCOUNT_DEFINE(_z_session_queryable, _z_session_queryable)
 _Z_ELEM_DEFINE(_z_session_queryable, _z_session_queryable_t, _z_noop_size, _z_session_queryable_clear, _z_noop_copy,
                _z_noop_move)
-_Z_ELEM_DEFINE(_z_session_queryable_rc, _z_session_queryable_rc_t, _z_noop_size, _z_session_queryable_rc_drop,
-               _z_noop_copy, _z_noop_move)
+_Z_ELEM_DEFINE(_z_session_queryable_rc, _z_session_queryable_rc_t, _z_session_queryable_rc_size,
+               _z_session_queryable_rc_drop, _z_session_queryable_rc_copy, _z_noop_move)
 _Z_LIST_DEFINE(_z_session_queryable_rc, _z_session_queryable_rc_t)
 
 // Forward declaration to avoid cyclical includes

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -215,7 +215,10 @@ typedef struct {
 } _z_declare_data_t;
 
 void _z_declare_data_clear(_z_declare_data_t *data);
-_Z_ELEM_DEFINE(_z_declare_data, _z_declare_data_t, _z_noop_size, _z_declare_data_clear, _z_noop_copy, _z_noop_move)
+size_t _z_declare_data_size(_z_declare_data_t *data);
+void _z_declare_data_copy(_z_declare_data_t *dst, const _z_declare_data_t *src);
+_Z_ELEM_DEFINE(_z_declare_data, _z_declare_data_t, _z_declare_data_size, _z_declare_data_clear, _z_declare_data_copy,
+               _z_noop_move)
 _Z_LIST_DEFINE(_z_declare_data, _z_declare_data_t)
 
 #ifdef __cplusplus

--- a/include/zenoh-pico/session/session.h
+++ b/include/zenoh-pico/session/session.h
@@ -52,7 +52,7 @@ void _z_resource_copy(_z_resource_t *dst, const _z_resource_t *src);
 void _z_resource_free(_z_resource_t **res);
 size_t _z_resource_size(_z_resource_t *p);
 
-_Z_ELEM_DEFINE(_z_resource, _z_resource_t, _z_noop_size, _z_resource_clear, _z_resource_copy, _z_noop_move)
+_Z_ELEM_DEFINE(_z_resource, _z_resource_t, _z_resource_size, _z_resource_clear, _z_resource_copy, _z_noop_move)
 _Z_LIST_DEFINE(_z_resource, _z_resource_t)
 
 _Z_ELEM_DEFINE(_z_keyexpr, _z_keyexpr_t, _z_keyexpr_size, _z_keyexpr_clear, _z_keyexpr_copy, _z_keyexpr_move)

--- a/include/zenoh-pico/transport/common/tx.h
+++ b/include/zenoh-pico/transport/common/tx.h
@@ -37,7 +37,7 @@ z_result_t _z_transport_tx_send_t_msg_wrapper(_z_transport_common_t *ztc, const 
 z_result_t _z_send_t_msg(_z_transport_t *zt, const _z_transport_message_t *t_msg);
 z_result_t _z_link_send_t_msg(const _z_link_t *zl, const _z_transport_message_t *t_msg, _z_sys_net_socket_t *socket);
 z_result_t _z_send_n_msg(_z_session_t *zn, const _z_network_message_t *n_msg, z_reliability_t reliability,
-                         z_congestion_control_t cong_ctrl);
+                         z_congestion_control_t cong_ctrl, void *peer);
 z_result_t _z_send_n_batch(_z_session_t *zn, z_congestion_control_t cong_ctrl);
 
 #ifdef __cplusplus

--- a/include/zenoh-pico/transport/transport.h
+++ b/include/zenoh-pico/transport/transport.h
@@ -198,7 +198,7 @@ typedef struct {
 } _z_transport_multicast_establish_param_t;
 
 z_result_t _z_transport_peer_unicast_add(_z_transport_unicast_t *ztu, _z_transport_unicast_establish_param_t *param,
-                                         _z_sys_net_socket_t socket);
+                                         _z_sys_net_socket_t socket, _z_transport_peer_unicast_t **output_peer);
 _z_transport_common_t *_z_transport_get_common(_z_transport_t *zt);
 z_result_t _z_transport_close(_z_transport_t *zt, uint8_t reason);
 void _z_transport_clear(_z_transport_t *zt);

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1022,8 +1022,8 @@ z_result_t z_declare_publisher(const z_loaned_session_t *zs, z_owned_publisher_t
     _z_keyexpr_t key = keyexpr_aliased;
 
     pub->_val = _z_publisher_null();
-    // TODO: Implement interest protocol for multicast transports, unicast p2p
-    if (_Z_RC_IN_VAL(zs)->_mode == Z_WHATAMI_CLIENT) {
+    // TODO: Implement interest protocol for multicast transports
+    if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
         _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &keyexpr_aliased, NULL);
         if (r == NULL) {
             uint16_t id = _z_declare_resource(_Z_RC_IN_VAL(zs), &keyexpr_aliased);
@@ -1373,8 +1373,8 @@ z_result_t z_declare_querier(const z_loaned_session_t *zs, z_owned_querier_t *qu
     _z_keyexpr_t key = keyexpr_aliased;
 
     querier->_val = _z_querier_null();
-    // TODO: Implement interest protocol for multicast transports, unicast p2p
-    if (_Z_RC_IN_VAL(zs)->_mode == Z_WHATAMI_CLIENT) {
+    // TODO: Implement interest protocol for multicast transports
+    if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
         _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &keyexpr_aliased, NULL);
         if (r == NULL) {
             uint16_t id = _z_declare_resource(_Z_RC_IN_VAL(zs), &keyexpr_aliased);
@@ -1612,8 +1612,8 @@ z_result_t z_declare_queryable(const z_loaned_session_t *zs, z_owned_queryable_t
     _z_keyexpr_t keyexpr_aliased = _z_keyexpr_alias_from_user_defined(*keyexpr, true);
     _z_keyexpr_t key = keyexpr_aliased;
 
-    // TODO: Implement interest protocol for multicast transports, unicast p2p
-    if (_Z_RC_IN_VAL(zs)->_mode == Z_WHATAMI_CLIENT) {
+    // TODO: Implement interest protocol for multicast transports
+    if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
         _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &keyexpr_aliased, NULL);
         if (r == NULL) {
             uint16_t id = _z_declare_resource(_Z_RC_IN_VAL(zs), &keyexpr_aliased);
@@ -1858,8 +1858,8 @@ z_result_t z_declare_subscriber(const z_loaned_session_t *zs, z_owned_subscriber
     _z_keyexpr_t keyexpr_aliased = _z_keyexpr_alias_from_user_defined(*keyexpr, true);
     _z_keyexpr_t key = _z_keyexpr_alias(&keyexpr_aliased);
 
-    // TODO: Implement interest protocol for multicast transports, unicast p2p
-    if (_Z_RC_IN_VAL(zs)->_mode == Z_WHATAMI_CLIENT) {
+    // TODO: Implement interest protocol for multicast transports
+    if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
         _z_resource_t *r = _z_get_resource_by_key(_Z_RC_IN_VAL(zs), &keyexpr_aliased, NULL);
         if (r == NULL) {
             bool do_keydecl = true;

--- a/src/api/api.c
+++ b/src/api/api.c
@@ -1044,14 +1044,18 @@ z_result_t z_declare_publisher(const z_loaned_session_t *zs, z_owned_publisher_t
     // Set publisher
     _z_publisher_t int_pub = _z_declare_publisher(zs, key, opt.encoding == NULL ? NULL : &opt.encoding->_this._val,
                                                   opt.congestion_control, opt.priority, opt.is_express, reliability);
-    // Create write filter
-    z_result_t res =
-        _z_write_filter_create(_Z_RC_IN_VAL(zs), &int_pub._filter, keyexpr_aliased, _Z_INTEREST_FLAG_SUBSCRIBERS);
-    if (res != _Z_RES_OK) {
-        if (key._id != Z_RESOURCE_ID_NONE) {
-            _z_undeclare_resource(_Z_RC_IN_VAL(zs), key._id);
+
+    // TODO: Implement interest protocol for multicast transports
+    if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
+        // Create write filter
+        z_result_t res =
+            _z_write_filter_create(_Z_RC_IN_VAL(zs), &int_pub._filter, keyexpr_aliased, _Z_INTEREST_FLAG_SUBSCRIBERS);
+        if (res != _Z_RES_OK) {
+            if (key._id != Z_RESOURCE_ID_NONE) {
+                _z_undeclare_resource(_Z_RC_IN_VAL(zs), key._id);
+            }
+            return res;
         }
-        return res;
     }
     pub->_val = int_pub;
     return _Z_RES_OK;
@@ -1393,14 +1397,17 @@ z_result_t z_declare_querier(const z_loaned_session_t *zs, z_owned_querier_t *qu
     _z_querier_t int_querier = _z_declare_querier(zs, key, opt.consolidation.mode, opt.congestion_control, opt.target,
                                                   opt.priority, opt.is_express, opt.timeout_ms,
                                                   opt.encoding == NULL ? NULL : &opt.encoding->_this._val, reliability);
-    // Create write filter
-    z_result_t res =
-        _z_write_filter_create(_Z_RC_IN_VAL(zs), &int_querier._filter, keyexpr_aliased, _Z_INTEREST_FLAG_QUERYABLES);
-    if (res != _Z_RES_OK) {
-        if (key._id != Z_RESOURCE_ID_NONE) {
-            _z_undeclare_resource(_Z_RC_IN_VAL(zs), key._id);
+    // TODO: Implement interest protocol for multicast transports
+    if (_Z_RC_IN_VAL(zs)->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
+        // Create write filter
+        z_result_t res = _z_write_filter_create(_Z_RC_IN_VAL(zs), &int_querier._filter, keyexpr_aliased,
+                                                _Z_INTEREST_FLAG_QUERYABLES);
+        if (res != _Z_RES_OK) {
+            if (key._id != Z_RESOURCE_ID_NONE) {
+                _z_undeclare_resource(_Z_RC_IN_VAL(zs), key._id);
+            }
+            return res;
         }
-        return res;
     }
     querier->_val = int_querier;
     return _Z_RES_OK;

--- a/src/net/filtering.c
+++ b/src/net/filtering.c
@@ -95,7 +95,7 @@ static void _z_write_filter_callback(const _z_interest_msg_t *msg, _z_transport_
     }
     // Process filter state
     switch (ctx->state) {
-        default: // Incorrect values are treated as init
+        default:  // Incorrect values are treated as init
         case WRITE_FILTER_INIT:
             // Update init state
             if (ctx->targets == NULL) {

--- a/src/net/filtering.c
+++ b/src/net/filtering.c
@@ -131,8 +131,6 @@ z_result_t _z_write_filter_create(_z_session_t *zn, _z_write_filter_t *filter, _
 #if Z_FEATURE_MULTI_THREAD == 1
     _Z_RETURN_IF_ERR(_z_mutex_init(&ctx->mutex));
 #endif
-    // FIXME: Require interest protocol profile implementation
-    // ctx->state = (zn->_mode == Z_WHATAMI_CLIENT) ? WRITE_FILTER_INIT : WRITE_FILTER_ACTIVE;
     ctx->state = WRITE_FILTER_INIT;
     ctx->targets = _z_filter_target_list_new();
 

--- a/src/net/filtering.c
+++ b/src/net/filtering.c
@@ -95,15 +95,7 @@ static void _z_write_filter_callback(const _z_interest_msg_t *msg, _z_transport_
     }
     // Process filter state
     switch (ctx->state) {
-        default:  // Incorrect values are treated as init
-        case WRITE_FILTER_INIT:
-            // Update init state
-            if (ctx->targets == NULL) {
-                ctx->state = WRITE_FILTER_ACTIVE;
-            } else {
-                ctx->state = WRITE_FILTER_OFF;
-            }
-            break;
+        default:  // Incorrect values are treated as active
         case WRITE_FILTER_ACTIVE:
             // Deactivate filter if no more targets
             if (ctx->targets != NULL) {
@@ -131,7 +123,7 @@ z_result_t _z_write_filter_create(_z_session_t *zn, _z_write_filter_t *filter, _
 #if Z_FEATURE_MULTI_THREAD == 1
     _Z_RETURN_IF_ERR(_z_mutex_init(&ctx->mutex));
 #endif
-    ctx->state = WRITE_FILTER_INIT;
+    ctx->state = WRITE_FILTER_ACTIVE;
     ctx->targets = _z_filter_target_list_new();
 
     filter->ctx = ctx;

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -45,7 +45,7 @@
 /*------------------ Declaration Helpers ------------------*/
 z_result_t _z_send_declare(_z_session_t *zn, const _z_network_message_t *n_msg) {
     z_result_t ret = _Z_RES_OK;
-    ret = _z_send_n_msg(zn, n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK);
+    ret = _z_send_n_msg(zn, n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL);
 
 #if Z_FEATURE_AUTO_RECONNECT == 1
     if (ret == _Z_RES_OK) {
@@ -58,7 +58,7 @@ z_result_t _z_send_declare(_z_session_t *zn, const _z_network_message_t *n_msg) 
 
 z_result_t _z_send_undeclare(_z_session_t *zn, const _z_network_message_t *n_msg) {
     z_result_t ret = _Z_RES_OK;
-    ret = _z_send_n_msg(zn, n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK);
+    ret = _z_send_n_msg(zn, n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL);
 
 #if Z_FEATURE_AUTO_RECONNECT == 1
     if (ret == _Z_RES_OK) {
@@ -241,7 +241,7 @@ z_result_t _z_write(_z_session_t *zn, const _z_keyexpr_t keyexpr, const _z_bytes
             return _Z_ERR_GENERIC;
     }
 
-    if (_z_send_n_msg(zn, &msg, reliability, cong_ctrl) != _Z_RES_OK) {
+    if (_z_send_n_msg(zn, &msg, reliability, cong_ctrl, NULL) != _Z_RES_OK) {
         ret = _Z_ERR_TRANSPORT_TX_FAILED;
     }
 
@@ -474,7 +474,7 @@ z_result_t _z_send_reply(const _z_query_t *query, const _z_session_rc_t *zsrc, c
             default:
                 return _Z_ERR_GENERIC;
         }
-        if (_z_send_n_msg(zn, &z_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) != _Z_RES_OK) {
+        if (_z_send_n_msg(zn, &z_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL) != _Z_RES_OK) {
             ret = _Z_ERR_TRANSPORT_TX_FAILED;
         }
 
@@ -509,7 +509,7 @@ z_result_t _z_send_reply_err(const _z_query_t *query, const _z_session_rc_t *zsr
                     },
             },
     };
-    if (_z_send_n_msg(zn, &msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) != _Z_RES_OK) {
+    if (_z_send_n_msg(zn, &msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL) != _Z_RES_OK) {
         ret = _Z_ERR_TRANSPORT_TX_FAILED;
     }
 
@@ -581,7 +581,7 @@ z_result_t _z_query(_z_session_t *zn, _z_keyexpr_t keyexpr, const char *paramete
             _z_zenoh_message_t z_msg = _z_msg_make_query(&keyexpr, &params, pq->_id, pq->_consolidation, &value,
                                                          timeout_ms, attachment, cong_ctrl, priority, is_express);
 
-            if (_z_send_n_msg(zn, &z_msg, Z_RELIABILITY_RELIABLE, cong_ctrl) != _Z_RES_OK) {
+            if (_z_send_n_msg(zn, &z_msg, Z_RELIABILITY_RELIABLE, cong_ctrl, NULL) != _Z_RES_OK) {
                 _z_unregister_pending_query(zn, pq);
                 ret = _Z_ERR_TRANSPORT_TX_FAILED;
             }
@@ -614,7 +614,7 @@ uint32_t _z_add_interest(_z_session_t *zn, _z_keyexpr_t keyexpr, _z_interest_han
     if (zn->_mode == Z_WHATAMI_CLIENT) {
         _z_interest_t interest = _z_make_interest(&keyexpr, intr._id, intr._flags);
         _z_network_message_t n_msg = _z_n_msg_make_interest(interest);
-        if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) != _Z_RES_OK) {
+        if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL) != _Z_RES_OK) {
             _z_unregister_interest(zn, sintr);
             return 0;
         }
@@ -633,7 +633,7 @@ z_result_t _z_remove_interest(_z_session_t *zn, uint32_t interest_id) {
     if (zn->_mode == Z_WHATAMI_CLIENT) {
         _z_interest_t interest = _z_make_interest_final(_Z_RC_IN_VAL(sintr)->_id);
         _z_network_message_t n_msg = _z_n_msg_make_interest(interest);
-        if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK) != _Z_RES_OK) {
+        if (_z_send_n_msg(zn, &n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL) != _Z_RES_OK) {
             return _Z_ERR_TRANSPORT_TX_FAILED;
         }
         _z_n_msg_clear(&n_msg);

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -620,6 +620,8 @@ uint32_t _z_add_interest(_z_session_t *zn, _z_keyexpr_t keyexpr, _z_interest_han
         }
         _z_n_msg_clear(&n_msg);
     }
+    // Replay declares
+    _z_interest_replay_declare(zn, &intr);
     return intr._id;
 }
 

--- a/src/net/primitives.c
+++ b/src/net/primitives.c
@@ -90,8 +90,8 @@ void _z_scout(const z_what_t what, const _z_id_t zid, _z_string_t *locator, cons
 uint16_t _z_declare_resource(_z_session_t *zn, const _z_keyexpr_t *keyexpr) {
     uint16_t ret = Z_RESOURCE_ID_NONE;
 
-    // TODO: Implement interest protocol for multicast transports, unicast p2p
-    if (zn->_mode == Z_WHATAMI_CLIENT) {
+    // TODO: Implement interest protocol for multicast transports
+    if (zn->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
         uint16_t id = _z_register_resource(zn, keyexpr, Z_RESOURCE_ID_NONE, NULL);
         if (id != 0) {
             // Build the declare message to send on the wire
@@ -143,8 +143,8 @@ _z_keyexpr_t _z_update_keyexpr_to_declared(_z_session_t *zs, _z_keyexpr_t keyexp
     _z_keyexpr_t keyexpr_aliased = _z_keyexpr_alias_from_user_defined(keyexpr, true);
     _z_keyexpr_t key = keyexpr_aliased;
 
-    // TODO: Implement interest protocol for multicast transports, unicast p2p
-    if (zs->_mode == Z_WHATAMI_CLIENT) {
+    // TODO: Implement interest protocol for multicast transports
+    if (zs->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
         _z_resource_t *r = _z_get_resource_by_key(zs, &keyexpr_aliased, NULL);
         if (r != NULL) {
             key = _z_rid_with_suffix(r->_id, NULL);

--- a/src/net/query.c
+++ b/src/net/query.c
@@ -32,7 +32,8 @@ z_result_t _z_query_send_reply_final(_z_query_t *q) {
         return _Z_ERR_TRANSPORT_TX_FAILED;
     }
     _z_zenoh_message_t z_msg = _z_n_msg_make_response_final(q->_request_id);
-    z_result_t ret = _z_send_n_msg(_Z_RC_IN_VAL(&sess_rc), &z_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK);
+    z_result_t ret =
+        _z_send_n_msg(_Z_RC_IN_VAL(&sess_rc), &z_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL);
     _z_msg_clear(&z_msg);
     _z_session_rc_drop(&sess_rc);
     return ret;

--- a/src/net/session.c
+++ b/src/net/session.c
@@ -223,7 +223,7 @@ z_result_t _z_reopen(_z_session_rc_t *zn) {
             _z_network_message_list_t *iter = zs->_decalaration_cache;
             while (iter != NULL) {
                 _z_network_message_t *n_msg = _z_network_message_list_head(iter);
-                ret = _z_send_n_msg(zs, n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK);
+                ret = _z_send_n_msg(zs, n_msg, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL);
                 if (ret != _Z_RES_OK) {
                     _Z_DEBUG("Send message during reopen failed: %i", ret);
                     continue;

--- a/src/session/interest.c
+++ b/src/session/interest.c
@@ -449,7 +449,7 @@ z_result_t _z_interest_process_interest(_z_session_t *zn, _z_keyexpr_t key, uint
     // TODO: process restricted flag & associated key
     _ZP_UNUSED(key);
     // Check transport type
-    if (zn->_mode == Z_WHATAMI_CLIENT) {
+    if (zn->_tp._type == _Z_TRANSPORT_UNICAST_TYPE) {
         return _Z_RES_OK;  // Nothing to do on unicast
     }
     // Current flags process

--- a/src/session/resource.c
+++ b/src/session/resource.c
@@ -269,7 +269,7 @@ void _z_unregister_resource(_z_session_t *zn, uint16_t id, _z_transport_peer_com
     uintptr_t mapping = _Z_KEYEXPR_MAPPING_LOCAL;
     if (peer != NULL) {
         is_local = false;
-        mapping = _Z_KEYEXPR_MAPPING_UNKNOWN_REMOTE;
+        mapping = (uintptr_t)peer;
     }
     _Z_DEBUG("unregistering: id %d, mapping: %d", id, (unsigned int)mapping);
     _z_session_mutex_lock(zn);

--- a/src/session/rx.c
+++ b/src/session/rx.c
@@ -114,7 +114,7 @@ static z_result_t _z_handle_request(_z_session_rc_t *zsrc, _z_session_t *zn, _z_
                                                           reliability, &put._commons._source_info, peer));
 #endif
             _z_network_message_t final = _z_n_msg_make_response_final(req->_rid);
-            z_result_t ret = _z_send_n_msg(zn, &final, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK);
+            z_result_t ret = _z_send_n_msg(zn, &final, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL);
 #if Z_FEATURE_SUBSCRIPTION == 0
             _z_n_msg_request_clear(req);
 #endif
@@ -129,7 +129,7 @@ static z_result_t _z_handle_request(_z_session_rc_t *zsrc, _z_session_t *zn, _z_
                                                           peer));
 #endif
             _z_network_message_t final = _z_n_msg_make_response_final(req->_rid);
-            z_result_t ret = _z_send_n_msg(zn, &final, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK);
+            z_result_t ret = _z_send_n_msg(zn, &final, Z_RELIABILITY_RELIABLE, Z_CONGESTION_CONTROL_BLOCK, NULL);
 #if Z_FEATURE_SUBSCRIPTION == 0
             _z_n_msg_request_clear(req);
 #endif

--- a/src/transport/manager.c
+++ b/src/transport/manager.c
@@ -46,7 +46,8 @@ static z_result_t _z_new_transport_client(_z_transport_t *zt, const _z_string_t 
             ret = _z_unicast_transport_create(zt, &zl, &tp_param);
             // Fill peer list
             if (ret == _Z_RES_OK) {
-                ret = _z_transport_peer_unicast_add(&zt->_transport._unicast, &tp_param, *_z_link_get_socket(&zl));
+                ret =
+                    _z_transport_peer_unicast_add(&zt->_transport._unicast, &tp_param, *_z_link_get_socket(&zl), NULL);
             }
             break;
         }
@@ -98,7 +99,8 @@ static z_result_t _z_new_transport_peer(_z_transport_t *zt, const _z_string_t *l
                 if (peer_op == _Z_PEER_OP_OPEN) {
                     ret = _z_socket_set_non_blocking(_z_link_get_socket(&zl));
                     if (ret == _Z_RES_OK) {
-                        _z_transport_peer_unicast_add(&zt->_transport._unicast, &tp_param, *_z_link_get_socket(&zl));
+                        _z_transport_peer_unicast_add(&zt->_transport._unicast, &tp_param, *_z_link_get_socket(&zl),
+                                                      NULL);
                     }
                 } else {
                     _zp_unicast_start_accept_task(&zt->_transport._unicast);
@@ -158,7 +160,7 @@ z_result_t _z_new_peer(_z_transport_t *zt, const _z_id_t *session_id, const _z_s
                 _z_socket_close(&socket);
                 return ret;
             }
-            ret = _z_transport_peer_unicast_add(&zt->_transport._unicast, &tp_param, socket);
+            ret = _z_transport_peer_unicast_add(&zt->_transport._unicast, &tp_param, socket, NULL);
         } break;
 
         default:

--- a/src/transport/multicast/lease.c
+++ b/src/transport/multicast/lease.c
@@ -112,30 +112,38 @@ void *_zp_multicast_lease_task(void *ztm_arg) {
     int next_keep_alive = (int)(next_lease / Z_TRANSPORT_LEASE_EXPIRE_FACTOR);
     int next_join = Z_JOIN_INTERVAL;
 
-    _z_transport_peer_multicast_list_t *it = NULL;
-    while (ztm->_common._lease_task_running == true) {
-        _z_transport_peer_mutex_lock(&ztm->_common);
-
+    while (ztm->_common._lease_task_running) {
         if (next_lease <= 0) {
-            it = ztm->_peers;
-            while (it != NULL) {
-                _z_transport_peer_multicast_t *entry = _z_transport_peer_multicast_list_head(it);
-                if (entry->common._received == true) {
+            _z_transport_peer_multicast_list_t *prev = NULL;
+            _z_transport_peer_multicast_list_t *prev_drop = NULL;
+            _z_transport_peer_mutex_lock(&ztm->_common);
+            _z_transport_peer_multicast_list_t *curr_list = ztm->_peers;
+            while (curr_list != NULL) {
+                bool drop_peer = false;
+                _z_transport_peer_multicast_t *curr_peer = _z_transport_peer_multicast_list_head(curr_list);
+                if (curr_peer->common._received) {
                     // Reset the lease parameters
-                    entry->common._received = false;
-                    entry->_next_lease = entry->_lease;
-                    it = _z_transport_peer_multicast_list_tail(it);
+                    curr_peer->common._received = false;
+                    curr_peer->_next_lease = curr_peer->_lease;
                 } else {
-                    _Z_INFO("Remove peer from know list because it has expired after %zums", entry->_lease);
+                    _Z_INFO("Deleting peer because it has expired after %zums", curr_peer->_lease);
+                    drop_peer = true;
+                    prev_drop = prev;
+                }
+                // Update previous only if current node is not dropped
+                if (!drop_peer) {
+                    prev = curr_list;
+                }
+                // Progress list
+                curr_list = _z_transport_peer_unicast_list_tail(curr_list);
+                // Drop if needed
+                if (drop_peer) {
                     // TODO: Drop peer references (sub/queryable cache + interests)
-                    _z_interest_peer_disconnected(_Z_RC_IN_VAL(ztm->_common._session), &entry->common);
-                    // FIXME: Remember parent and use _z_transport_peer_multicast_list_drop_element to avoid recursive
-                    // list parsing
-                    ztm->_peers = _z_transport_peer_multicast_list_drop_filter(ztm->_peers,
-                                                                               _z_transport_peer_multicast_eq, entry);
-                    it = ztm->_peers;
+                    _z_interest_peer_disconnected(_Z_RC_IN_VAL(ztm->_common._session), &curr_peer->common);
+                    ztm->_peers = _z_transport_peer_multicast_list_drop_element(ztm->_peers, prev_drop);
                 }
             }
+            _z_transport_peer_mutex_unlock(&ztm->_common);
         }
 
         if (next_join <= 0) {
@@ -159,6 +167,7 @@ void *_zp_multicast_lease_task(void *ztm_arg) {
             next_keep_alive =
                 (int)(_z_get_minimum_lease(ztm->_peers, ztm->_common._lease) / Z_TRANSPORT_LEASE_EXPIRE_FACTOR);
         }
+
         // Query timeout process
         _z_pending_query_process_timeout(_Z_RC_IN_VAL(ztm->_common._session));
 
@@ -179,17 +188,14 @@ void *_zp_multicast_lease_task(void *ztm_arg) {
             }
         }
 
-        _z_transport_peer_mutex_unlock(&ztm->_common);
-
         // The keep alive and lease intervals are expressed in milliseconds
         z_sleep_ms((size_t)interval);
 
         // Decrement all intervals
         _z_transport_peer_mutex_lock(&ztm->_common);
-
-        it = ztm->_peers;
-        while (it != NULL) {
-            _z_transport_peer_multicast_t *entry = _z_transport_peer_multicast_list_head(it);
+        _z_transport_peer_multicast_list_t *curr_list = ztm->_peers;
+        while (curr_list != NULL) {
+            _z_transport_peer_multicast_t *entry = _z_transport_peer_multicast_list_head(curr_list);
             int entry_next_lease = (int)entry->_next_lease - interval;
             if (entry_next_lease >= 0) {
                 entry->_next_lease = (size_t)entry_next_lease;
@@ -197,13 +203,12 @@ void *_zp_multicast_lease_task(void *ztm_arg) {
                 _Z_ERROR("Negative next lease value");
                 entry->_next_lease = 0;
             }
-            it = _z_transport_peer_multicast_list_tail(it);
+            curr_list = _z_transport_peer_multicast_list_tail(curr_list);
         }
         next_lease = (int)_z_get_next_lease(ztm->_peers);
+        _z_transport_peer_mutex_unlock(&ztm->_common);
         next_keep_alive = next_keep_alive - interval;
         next_join = next_join - interval;
-
-        _z_transport_peer_mutex_unlock(&ztm->_common);
     }
     return 0;
 }

--- a/src/transport/multicast/lease.c
+++ b/src/transport/multicast/lease.c
@@ -138,7 +138,8 @@ void *_zp_multicast_lease_task(void *ztm_arg) {
                 curr_list = _z_transport_peer_unicast_list_tail(curr_list);
                 // Drop if needed
                 if (drop_peer) {
-                    // TODO: Drop peer references (sub/queryable cache + interests)
+                    _z_subscription_cache_invalidate(_Z_RC_IN_VAL(ztm->_common._session));
+                    _z_queryable_cache_invalidate(_Z_RC_IN_VAL(ztm->_common._session));
                     _z_interest_peer_disconnected(_Z_RC_IN_VAL(ztm->_common._session), &curr_peer->common);
                     ztm->_peers = _z_transport_peer_multicast_list_drop_element(ztm->_peers, prev_drop);
                 }

--- a/src/transport/multicast/read.c
+++ b/src/transport/multicast/read.c
@@ -65,7 +65,7 @@ void *_zp_multicast_read_task(void *ztm_arg) {
 
     uint8_t addr_buff[_Z_MULTICAST_ADDR_BUFF_SIZE] = {0};
     _z_slice_t addr = _z_slice_alias_buf(addr_buff, sizeof(addr_buff));
-    while (ztm->_common._read_task_running == true) {
+    while (ztm->_common._read_task_running) {
         size_t to_read = 0;
 
         // Read bytes from socket to the main buffer

--- a/src/transport/peer.c
+++ b/src/transport/peer.c
@@ -88,7 +88,7 @@ bool _z_transport_peer_unicast_eq(const _z_transport_peer_unicast_t *left, const
 }
 
 z_result_t _z_transport_peer_unicast_add(_z_transport_unicast_t *ztu, _z_transport_unicast_establish_param_t *param,
-                                         _z_sys_net_socket_t socket) {
+                                         _z_sys_net_socket_t socket, _z_transport_peer_unicast_t **output_peer) {
     // Create peer
     _z_transport_peer_unicast_t *peer = (_z_transport_peer_unicast_t *)z_malloc(sizeof(_z_transport_peer_unicast_t));
     if (peer == NULL) {
@@ -120,6 +120,9 @@ z_result_t _z_transport_peer_unicast_add(_z_transport_unicast_t *ztu, _z_transpo
     _z_transport_peer_mutex_unlock(&ztu->_common);
     if (ztu->_peers == NULL) {
         return _Z_ERR_SYSTEM_OUT_OF_MEMORY;
+    }
+    if (output_peer != NULL) {
+        *output_peer = peer;
     }
     return _Z_RES_OK;
 }

--- a/src/transport/raweth/read.c
+++ b/src/transport/raweth/read.c
@@ -59,7 +59,7 @@ void *_zp_raweth_read_task(void *ztm_arg) {
     _z_slice_t addr = _z_slice_alias_buf(NULL, 0);
 
     // Task loop
-    while (ztm->_common._read_task_running == true) {
+    while (ztm->_common._read_task_running) {
         // Read message from link
         z_result_t ret = _z_raweth_recv_t_msg(ztm, &t_msg, &addr);
         switch (ret) {

--- a/src/transport/unicast/accept.c
+++ b/src/transport/unicast/accept.c
@@ -12,6 +12,7 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
+#include "zenoh-pico/session/interest.h"
 #include "zenoh-pico/session/liveliness.h"
 #include "zenoh-pico/session/query.h"
 #include "zenoh-pico/system/common/platform.h"
@@ -61,7 +62,11 @@ static void *_zp_unicast_accept_task(void *ctx) {
             continue;
         }
         // Add peer
-        _z_transport_peer_unicast_add(ztu, &param, con_socket);
+        _z_transport_peer_unicast_t *new_peer;
+        _z_transport_peer_unicast_add(ztu, &param, con_socket, &new_peer);
+        if (new_peer != NULL) {
+            _z_interest_push_declarations_to_peer(_Z_RC_IN_VAL(ztu->_common._session), (void *)new_peer);
+        }
     }
     z_free(accept_task_is_running);
     return NULL;

--- a/src/transport/unicast/lease.c
+++ b/src/transport/unicast/lease.c
@@ -134,7 +134,8 @@ void *_zp_unicast_lease_task(void *ztu_arg) {
                     curr_list = _z_transport_peer_unicast_list_tail(curr_list);
                     // Drop if needed
                     if (drop_peer) {
-                        // TODO: Drop peer references (sub/queryable cache + interests)
+                        _z_subscription_cache_invalidate(_Z_RC_IN_VAL(ztu->_common._session));
+                        _z_queryable_cache_invalidate(_Z_RC_IN_VAL(ztu->_common._session));
                         _z_interest_peer_disconnected(_Z_RC_IN_VAL(ztu->_common._session), &curr_peer->common);
                         ztu->_peers = _z_transport_peer_unicast_list_drop_element(ztu->_peers, prev_drop);
                     }

--- a/src/transport/unicast/read.c
+++ b/src/transport/unicast/read.c
@@ -338,7 +338,8 @@ void *_zp_unicast_read_task(void *ztu_arg) {
                 // Drop peer if needed
                 if (drop_peer) {
                     _Z_DEBUG("Dropping peer");
-                    // TODO: Drop peer references (sub/queryable cache + filter target)
+                    _z_subscription_cache_invalidate(_Z_RC_IN_VAL(ztu->_common._session));
+                    _z_queryable_cache_invalidate(_Z_RC_IN_VAL(ztu->_common._session));
                     _z_interest_peer_disconnected(_Z_RC_IN_VAL(ztu->_common._session), &curr_peer->common);
                     ztu->_peers = _z_transport_peer_unicast_list_drop_element(ztu->_peers, prev_drop);
                 }


### PR DESCRIPTION
This is a misc one:
* Rework of multicast peer deletion to avoid O(n²) recursive list parsing.
* Add cache invalidation on peer disconnection.
* Implement p2p unicast interest profile (push declaration on a single peer at connection accept)
* Activate resource declaration for p2p unicast
* Misc bugfixes discovered by reactivating all of this