### PR TITLE
Fix single thread examples

### DIFF
--- a/examples/freertos_plus_tcp/z_pub_st.c
+++ b/examples/freertos_plus_tcp/z_pub_st.c
@@ -59,6 +59,8 @@ void app_main(void) {
         printf("Unable to declare publisher for key expression!\n");
         return;
     }
+    // Read received declaration
+    zp_read(z_loan(s), NULL);
 
     char *buf = (char *)pvPortMalloc(256);
     z_clock_t now = z_clock_now();

--- a/examples/rpi_pico/z_pub_st.c
+++ b/examples/rpi_pico/z_pub_st.c
@@ -50,6 +50,8 @@ void app_main(void) {
         printf("Unable to declare publisher for key expression!\n");
         return;
     }
+    // Read received declaration
+    zp_read(z_loan(s), NULL);
 
     char *buf = (char *)pvPortMalloc(256);
     z_clock_t now = z_clock_now();

--- a/examples/unix/c11/z_sub_st.c
+++ b/examples/unix/c11/z_sub_st.c
@@ -71,10 +71,16 @@ int main(int argc, char **argv) {
     }
 
     printf("Press CTRL-C to quit...\n");
+    z_clock_t pulse_time = z_clock_now();
     while (msg_nb < n) {
+        z_sleep_ms(50);
         zp_read(z_loan(s), NULL);
-        zp_send_keep_alive(z_loan(s), NULL);
-        zp_send_join(z_loan(s), NULL);
+        unsigned long elapsed_ms = z_clock_elapsed_ms(&pulse_time);
+        if (elapsed_ms >= (Z_TRANSPORT_LEASE / Z_TRANSPORT_LEASE_EXPIRE_FACTOR)) {
+            pulse_time = z_clock_now();
+            zp_send_keep_alive(z_loan(s), NULL);
+            zp_send_join(z_loan(s), NULL);
+        }
     }
     z_drop(z_move(sub));
     z_drop(z_move(s));

--- a/examples/unix/c99/z_pub_st.c
+++ b/examples/unix/c99/z_pub_st.c
@@ -90,6 +90,8 @@ int main(int argc, char **argv) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }
+    // Read received declaration
+    zp_read(z_session_loan(&s), NULL);
 
     printf("Press CTRL-C to quit...\n");
     char *buf = (char *)malloc(256);

--- a/examples/windows/z_pub_st.c
+++ b/examples/windows/z_pub_st.c
@@ -54,6 +54,8 @@ int main(int argc, char **argv) {
         printf("Unable to declare publisher for key expression!\n");
         return -1;
     }
+    // Read received declaration
+    zp_read(z_loan(s), NULL);
 
     printf("Press CTRL-C to quit...\n");
     char *buf = (char *)malloc(256);


### PR DESCRIPTION
Single thread publisher should read received declarations before publishing to avoid a wrongly activated write filter