### PR TITLE
fix: include z_open result code in error messages

### DIFF
--- a/examples/unix/c11/z_get.c
+++ b/examples/unix/c11/z_get.c
@@ -71,8 +71,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_get_attachment.c
+++ b/examples/unix/c11/z_get_attachment.c
@@ -107,8 +107,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_get_channel.c
+++ b/examples/unix/c11/z_get_channel.c
@@ -36,8 +36,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_get_lat.c
+++ b/examples/unix/c11/z_get_lat.c
@@ -62,8 +62,9 @@ int main(int argc, char **argv) {
 
     // Open session
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         exit(-1);
     }
     // Start read and lease tasks for zenoh-pico

--- a/examples/unix/c11/z_get_liveliness.c
+++ b/examples/unix/c11/z_get_liveliness.c
@@ -33,8 +33,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_info.c
+++ b/examples/unix/c11/z_info.c
@@ -40,8 +40,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_liveliness.c
+++ b/examples/unix/c11/z_liveliness.c
@@ -35,8 +35,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_ping.c
+++ b/examples/unix/c11/z_ping.c
@@ -63,8 +63,9 @@ int main(int argc, char** argv) {
     }
 
     z_owned_session_t session;
-    if (z_open(&session, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&session, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
     if (zp_start_read_task(z_loan_mut(session), NULL) < 0) {

--- a/examples/unix/c11/z_pong.c
+++ b/examples/unix/c11/z_pong.c
@@ -39,8 +39,9 @@ int main(int argc, char** argv) {
     }
 
     z_owned_session_t session;
-    if (z_open(&session, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&session, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_pub.c
+++ b/examples/unix/c11/z_pub.c
@@ -53,8 +53,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_pub_attachment.c
+++ b/examples/unix/c11/z_pub_attachment.c
@@ -47,8 +47,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_pub_st.c
+++ b/examples/unix/c11/z_pub_st.c
@@ -39,8 +39,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_pub_thr.c
+++ b/examples/unix/c11/z_pub_thr.c
@@ -134,8 +134,9 @@ int main(int argc, char **argv) {
 
     // Open session
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         exit(-1);
     }
     // Start read and lease tasks for zenoh-pico

--- a/examples/unix/c11/z_pull.c
+++ b/examples/unix/c11/z_pull.c
@@ -38,8 +38,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_put.c
+++ b/examples/unix/c11/z_put.c
@@ -42,8 +42,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_querier.c
+++ b/examples/unix/c11/z_querier.c
@@ -50,8 +50,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_queryable.c
+++ b/examples/unix/c11/z_queryable.c
@@ -84,8 +84,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_queryable_attachment.c
+++ b/examples/unix/c11/z_queryable_attachment.c
@@ -128,8 +128,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_queryable_channel.c
+++ b/examples/unix/c11/z_queryable_channel.c
@@ -36,8 +36,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_queryable_lat.c
+++ b/examples/unix/c11/z_queryable_lat.c
@@ -74,8 +74,9 @@ int main(int argc, char **argv) {
 
     // Open session
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         exit(-1);
     }
     // Start read and lease tasks for zenoh-pico

--- a/examples/unix/c11/z_sub.c
+++ b/examples/unix/c11/z_sub.c
@@ -52,8 +52,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_sub_attachment.c
+++ b/examples/unix/c11/z_sub_attachment.c
@@ -101,8 +101,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_sub_channel.c
+++ b/examples/unix/c11/z_sub_channel.c
@@ -35,8 +35,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_sub_liveliness.c
+++ b/examples/unix/c11/z_sub_liveliness.c
@@ -57,8 +57,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_sub_st.c
+++ b/examples/unix/c11/z_sub_st.c
@@ -51,8 +51,9 @@ int main(int argc, char **argv) {
 
     printf("Opening session...\n");
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         return -1;
     }
 

--- a/examples/unix/c11/z_sub_thr.c
+++ b/examples/unix/c11/z_sub_thr.c
@@ -79,8 +79,9 @@ int main(int argc, char **argv) {
 
     // Open session
     z_owned_session_t s;
-    if (z_open(&s, z_move(config), NULL) < 0) {
-        printf("Unable to open session!\n");
+    int ret = z_open(&s, z_move(config), NULL);
+    if (ret < 0) {
+        printf("Unable to open session! (result: %d)\n", ret);
         exit(-1);
     }
     // Start read and lease tasks for zenoh-pico


### PR DESCRIPTION
## Summary
- Include actual z_open return code in error messages for all examples
- Changes generic "Unable to open session\!" to "Unable to open session\! (result: %d)"
- Helps developers debug connection issues by showing specific error codes

## Test plan
- [ ] Verify examples compile successfully
- [ ] Test error message format when z_open fails
- [ ] Confirm no functional changes to example behavior